### PR TITLE
Handle errors when browser launching fails

### DIFF
--- a/.changeset/wicked-pumpkins-join.md
+++ b/.changeset/wicked-pumpkins-join.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Handle errors thrown by browser launcher instead of silently hanging

--- a/src/start-disowned-browser.ts
+++ b/src/start-disowned-browser.ts
@@ -4,52 +4,56 @@ import { promises as fs } from 'fs';
 import puppeteer from 'puppeteer';
 
 process.on('message', async ({ browser, headless }) => {
-  if (browser !== 'chromium')
-    throw new Error(`unrecognized browser: ${browser}`);
-  if (typeof headless !== 'boolean')
-    throw new Error('headless must be a boolean');
+  try {
+    if (browser !== 'chromium')
+      throw new Error(`unrecognized browser: ${browser}`);
+    if (typeof headless !== 'boolean')
+      throw new Error('headless must be a boolean');
 
-  let userDataDir: string | undefined;
-  if (browser === 'chromium') {
-    userDataDir = await fs.mkdtemp(os.tmpdir() + path.sep);
-    const prefs = JSON.stringify({
-      devtools: {
-        preferences: {
-          'panel-selectedTab': JSON.stringify('console'),
-          currentDockState: JSON.stringify('right'),
-          'InspectorView.splitViewState': JSON.stringify({
-            horizontal: { size: 600 },
-            vertical: { size: 450 },
-          }),
+    let userDataDir: string | undefined;
+    if (browser === 'chromium') {
+      userDataDir = await fs.mkdtemp(os.tmpdir() + path.sep);
+      const prefs = JSON.stringify({
+        devtools: {
+          preferences: {
+            'panel-selectedTab': JSON.stringify('console'),
+            currentDockState: JSON.stringify('right'),
+            'InspectorView.splitViewState': JSON.stringify({
+              horizontal: { size: 600 },
+              vertical: { size: 450 },
+            }),
+          },
         },
-      },
-    });
-    const prefsPath = path.join(userDataDir, 'Default', 'Preferences');
-    await fs.mkdir(path.dirname(prefsPath), { recursive: true });
-    await fs.writeFile(prefsPath, prefs);
-  }
+      });
+      const prefsPath = path.join(userDataDir, 'Default', 'Preferences');
+      await fs.mkdir(path.dirname(prefsPath), { recursive: true });
+      await fs.writeFile(prefsPath, prefs);
+    }
 
-  const browserInstance = await puppeteer.launch({
-    headless,
-    devtools: !headless,
-    ignoreDefaultArgs: [
-      // Don't pop up "Chrome is being controlled by automated software"
-      '--enable-automation',
-      // Unsupported flag that pops up a warning
-      '--enable-blink-features=IdleDetection',
-    ],
-    args: [
-      // Don't pop up "Chrome is not your default browser"
-      '--no-default-browser-check',
-      '--disable-features=ChromeLabs', // Remove little beaker icon next to URL bar
-    ],
-    userDataDir,
-  });
-  const allPages = await browserInstance.pages();
-  // Close startup page
-  await Promise.all(allPages.map((p) => p.close()));
-  const browserWSEndpoint = browserInstance.wsEndpoint();
-  process.send!({ browserWSEndpoint });
-  // eslint-disable-next-line no-process-exit
-  browserInstance.on('disconnected', () => process.exit());
+    const browserInstance = await puppeteer.launch({
+      headless,
+      devtools: !headless,
+      ignoreDefaultArgs: [
+        // Don't pop up "Chrome is being controlled by automated software"
+        '--enable-automation',
+        // Unsupported flag that pops up a warning
+        '--enable-blink-features=IdleDetection',
+      ],
+      args: [
+        // Don't pop up "Chrome is not your default browser"
+        '--no-default-browser-check',
+        '--disable-features=ChromeLabs', // Remove little beaker icon next to URL bar
+      ],
+      userDataDir,
+    });
+    const allPages = await browserInstance.pages();
+    // Close startup page
+    await Promise.all(allPages.map((p) => p.close()));
+    const browserWSEndpoint = browserInstance.wsEndpoint();
+    process.send!({ browserWSEndpoint });
+    // eslint-disable-next-line no-process-exit
+    browserInstance.on('disconnected', () => process.exit());
+  } catch (error) {
+    process.send!({ error: error.message });
+  }
 });


### PR DESCRIPTION
This PR fixes a bug I noticed on cloudfour-patterns.

Previously, if npm failed to run the postinstall script for puppeteer (or ignored it? I noticed npm@7 ignores postinstall scripts sometimes), then when you run pleasantest, here is what would happen:
```
Pleasantest sees that there is no cached browser instance to connect to
Pleasantest spawns a new process to launch a new browser
In the spawned process, puppeteer.launch() is called
puppeteer.launch() throws an error, saying that the browser binary is missing, but since it is in a child process, the error is not displayed anywhere
---
5 seconds later: Jest force-quits the test because it timed out
```

Now, errors that are thrown in the child process get passed to the main process, where they are thrown:

```
Failed to start browser: Could not find expected browser (chrome) locally. Run `npm install` to download the correct Chromium revision (869685).
```

## Testing

- `npm ci`
- Lose the browser binary: `rm -rf node_modules/puppeteer/.local-chromium`
- Clear out any references to cached browser instances: `rm /Users/<your username>/Library/Application\ Support/pleasantest-nodejs/config.json`
- Run a test (probably just one, running them all takes a long time if they are all failing): `npm run test toBeVisible`. It should fail and display a helpful message.
- Run the test again (or another test). It should fail again with the same message. (This is to make sure that it does not try to cache the browser that failed to launch the first time)
- `node ./node_modules/puppeteer/install.js` to re-download the browser binaries
- `npm run test` should pass