### PR TITLE
Add source maps to module server

### DIFF
--- a/.changeset/nice-chairs-chew.md
+++ b/.changeset/nice-chairs-chew.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': minor
+---
+
+Improve error message display for errors coming from browsers

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "source-map": "0.8.0-beta.0"
       },
       "devDependencies": {
+        "@ampproject/remapping": "1.0.1",
         "@babel/core": "7.14.6",
         "@babel/preset-env": "7.14.7",
         "@babel/preset-typescript": "7.14.5",
@@ -60,11 +61,25 @@
         "rollup-plugin-prettier": "2.1.0",
         "rollup-plugin-terser": "7.0.2",
         "sass": "1.35.1",
+        "simple-code-frame": "1.1.1",
         "smoldash": "0.9.0",
         "typescript": "4.3.4"
       },
       "engines": {
         "node": "12 || 14 || 16"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-1.0.1.tgz",
+      "integrity": "sha512-Ta9bMA3EtUHDaZJXqUoT5cn/EecwOp+SXpKJqxDbDuMbLvEMu6YTyDDuvTWeStODfdmXyfMo7LymQyPkN3BicA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "1.0.0",
+        "sourcemap-codec": "1.4.8"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@arr/every": {
@@ -3732,6 +3747,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
+      "integrity": "sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -19137,6 +19161,15 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-code-frame": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/simple-code-frame/-/simple-code-frame-1.1.1.tgz",
+      "integrity": "sha512-Xi3wMZQScdiJbg9+nuSIp3aG5FIBd+GMvxPf9tOB1v102/yfngTgQU9aSnULgtYSGqrSqqdMOKunMy+Jhx871g==",
+      "dev": true,
+      "dependencies": {
+        "kolorist": "^1.4.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -21743,6 +21776,16 @@
     }
   },
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-1.0.1.tgz",
+      "integrity": "sha512-Ta9bMA3EtUHDaZJXqUoT5cn/EecwOp+SXpKJqxDbDuMbLvEMu6YTyDDuvTWeStODfdmXyfMo7LymQyPkN3BicA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "1.0.0",
+        "sourcemap-codec": "1.4.8"
+      }
+    },
     "@arr/every": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.1.tgz",
@@ -24498,6 +24541,12 @@
           }
         }
       }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
+      "integrity": "sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==",
+      "dev": true
     },
     "@manypkg/find-root": {
       "version": "1.1.0",
@@ -36211,6 +36260,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simple-code-frame": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/simple-code-frame/-/simple-code-frame-1.1.1.tgz",
+      "integrity": "sha512-Xi3wMZQScdiJbg9+nuSIp3aG5FIBd+GMvxPf9tOB1v102/yfngTgQU9aSnULgtYSGqrSqqdMOKunMy+Jhx871g==",
+      "dev": true,
+      "requires": {
+        "kolorist": "^1.4.0"
+      }
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@ampproject/remapping": "1.0.1",
     "@babel/core": "7.14.6",
     "@babel/preset-env": "7.14.7",
     "@babel/preset-typescript": "7.14.5",
@@ -47,6 +48,7 @@
     "rollup-plugin-prettier": "2.1.0",
     "rollup-plugin-terser": "7.0.2",
     "sass": "1.35.1",
+    "simple-code-frame": "1.1.1",
     "smoldash": "0.9.0",
     "typescript": "4.3.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -334,7 +334,6 @@ const createTab = async ({
         return stackItem.raw;
       const mappedColumn = sourceLocation.column + 1;
       const mappedLine = sourceLocation.line;
-      // The check for i === 0 is because Jest fails to recognize
       const mappedPath = sourceLocation.source || url.pathname;
       // If the stack frame has a name (i.e. function name), then display it
       // _unless_ the stack frame is the first frame

--- a/src/module-server/combine-source-maps.ts
+++ b/src/module-server/combine-source-maps.ts
@@ -1,0 +1,80 @@
+// Copied from https://github.com/vitejs/vite/blob/d97b33a8cb9a72ed64244f239900a9a862b6ba68/packages/vite/src/node/utils.ts#L431
+
+/*
+  https://github.com/vitejs/vite/blob/main/LICENSE
+  MIT License
+  Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+  */
+
+/*
+  Differences from original:
+  - Function style changed
+  - ESLint fixes
+  - Order of source maps is reversed in input
+  - Make it not break if a sourcemap is missing sources
+  */
+
+import remapping from '@ampproject/remapping';
+import type {
+  DecodedSourceMap,
+  RawSourceMap,
+} from '@ampproject/remapping/dist/types/types';
+
+// Based on https://github.com/sveltejs/svelte/blob/abf11bb02b2afbd3e4cac509a0f70e318c306364/src/compiler/utils/mapped_code.ts#L221
+const nullSourceMap: RawSourceMap = {
+  names: [],
+  sources: [],
+  mappings: '',
+  version: 3,
+};
+export const combineSourceMaps = (
+  filename: string,
+  _sourceMapList: (DecodedSourceMap | RawSourceMap)[],
+): RawSourceMap => {
+  const sourceMapList = _sourceMapList
+    .map((map) => {
+      // eslint-disable-next-line @cloudfour/typescript-eslint/no-unnecessary-condition
+      if (!map.sources) map.sources = [];
+      return map;
+    })
+    .reverse();
+  if (
+    sourceMapList.length === 0 ||
+    sourceMapList.every((m) => m.sources.length === 0)
+  )
+    return { ...nullSourceMap };
+
+  let mapIndex = 1;
+  const useArrayInterface =
+    sourceMapList.slice(0, -1).find((m) => m.sources.length !== 1) ===
+    undefined;
+  const map = useArrayInterface
+    ? remapping(sourceMapList, () => null, true)
+    : remapping(
+        sourceMapList[0],
+        (sourcefile) =>
+          sourcefile === filename && sourceMapList[mapIndex]
+            ? sourceMapList[mapIndex++]
+            : { ...nullSourceMap },
+        true,
+      );
+
+  if (!map.file) delete map.file;
+
+  return map as RawSourceMap;
+};

--- a/src/module-server/index.ts
+++ b/src/module-server/index.ts
@@ -1,5 +1,5 @@
 import type polka from 'polka';
-import type { Plugin } from 'rollup';
+import type { Plugin, SourceDescription } from 'rollup';
 import { indexHTMLMiddleware } from './middleware/index-html';
 import { jsMiddleware } from './middleware/js';
 import { npmPlugin } from './plugins/npm-plugin';
@@ -37,11 +37,15 @@ export const createModuleServer = async ({
     cssPlugin(),
   ];
   const filteredPlugins = plugins.filter(Boolean) as Plugin[];
+  const requestCache = new Map<string, SourceDescription>();
   const middleware: polka.Middleware[] = [
     indexHTMLMiddleware,
-    jsMiddleware({ root, plugins: filteredPlugins }),
+    jsMiddleware({ root, plugins: filteredPlugins, requestCache }),
     cssMiddleware({ root }),
     staticMiddleware({ root }),
   ];
-  return createServer({ middleware });
+  return {
+    ...(await createServer({ middleware })),
+    requestCache,
+  };
 };

--- a/src/module-server/plugins/esbuild-plugin.ts
+++ b/src/module-server/plugins/esbuild-plugin.ts
@@ -13,9 +13,19 @@ export const esbuildPlugin = (): Plugin => {
     async transform(code, id) {
       if (!shouldProcess(id)) return null;
       const loader = extname(id).slice(1) as esbuild.Loader;
-      const result = await esbuild.transform(code, { sourcefile: id, loader });
-
-      return result.code;
+      return esbuild
+        .transform(code, {
+          sourcefile: id,
+          loader,
+          sourcemap: 'external',
+        })
+        .catch((error) => {
+          const err = error.errors[0];
+          this.error(err.text, {
+            line: err.location.line,
+            column: err.location.column,
+          });
+        });
     },
   };
 };

--- a/src/module-server/plugins/npm-plugin.ts
+++ b/src/module-server/plugins/npm-plugin.ts
@@ -78,6 +78,9 @@ const nodeResolve = async (id: string, root: string) => {
   const packageName = pathChunks.slice(0, isNpmNamespace ? 2 : 1);
   // If it is an npm namespace, then get the first two folders, otherwise just one
   const pkgDir = join(root, 'node_modules', ...packageName);
+  await fs.stat(pkgDir).catch(() => {
+    throw new Error(`Could not resolve ${id} from ${root}`);
+  });
   // Path within imported module
   const subPath = join(...pathChunks.slice(isNpmNamespace ? 2 : 1));
   const pkgJsonPath = join(pkgDir, 'package.json');

--- a/src/module-server/server.ts
+++ b/src/module-server/server.ts
@@ -1,3 +1,4 @@
+import { Console } from 'console';
 import type { AddressInfo, Socket } from 'net';
 import type { Polka } from 'polka';
 import polka from 'polka';
@@ -30,7 +31,10 @@ export const createServer = ({ middleware }: ServerOpts) =>
           res.writeHead(code, { 'content-type': 'text/plain' });
           if (code === 404) return res.end('not found');
           res.end(err.stack);
-          console.error(err.stack);
+          // Create a new console instance instead of using the global one
+          // Because the global one is overridden by Jest, and it adds a misleading second stack trace and code frame below it
+          const console = new Console(process.stdout, process.stderr);
+          console.log(err.stack);
         },
       });
       if (middleware.length > 0) server.use(...middleware);

--- a/tests/test-utils.test.ts
+++ b/tests/test-utils.test.ts
@@ -1,6 +1,6 @@
 import { printErrorFrames } from './test-utils';
 
-test('printErrorFrames', async () => {
+test('printErrorFrames with native stack trace', async () => {
   const error = await fnThatThrows().catch((error) => error);
   expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
     "Error: this is an error
@@ -15,6 +15,32 @@ test('printErrorFrames', async () => {
       const error = await fnThatThrows().catch((error) => error);
                           ^"
   `);
+});
+
+test('printErrorFrames with browser-made stack trace', async () => {
+  const error = new Error('something');
+  error.stack = `Error: something
+        at ${process.cwd()}/tests/utils/external.tsx:14:9
+        at S.re [as render] (http://localhost:56999/@npm/preact:1:8041)
+        at W (http://localhost:56999/@npm/preact:1:5810)
+        at B (http://localhost:56999/@npm/preact:1:2144)
+        at W (http://localhost:56999/@npm/preact:1:6043)
+        at Y (http://localhost:56999/@npm/preact:1:8155)
+        at renderThrow (tests/utils/external.tsx:18:3)`;
+
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+"Error: something
+-------------------------------------------------------
+tests/utils/external.tsx
+
+  throw new Error('you have rendered the death component');
+        ^
+-------------------------------------------------------
+tests/utils/external.tsx
+
+  preactRender(<ThrowComponent />, document.body);
+  ^"
+`);
 });
 
 // eslint-disable-next-line @cloudfour/typescript-eslint/require-await

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -6,32 +6,41 @@ export const printErrorFrames = async (error?: Error) => {
   if (!error?.stack) return '';
   const stack = parseStackTrace(error.stack);
 
-  const frames = await Promise.all(
-    stack
-      .filter(
-        (stackFrame) =>
-          stackFrame.fileName &&
-          !/node_modules/.test(stackFrame.fileName) &&
-          stackFrame.fileName.startsWith('/'),
-      )
-      .map(async (stackFrame) => {
-        if (
-          !stackFrame.fileName ||
-          stackFrame.line === -1 ||
-          stackFrame.column === -1
-        ) {
-          return stackFrame.raw;
-        }
+  const frames = (
+    await Promise.all(
+      stack
+        .filter(
+          (stackFrame) =>
+            stackFrame.fileName && !/node_modules/.test(stackFrame.fileName),
+        )
+        .map(async (stackFrame) => {
+          if (
+            !stackFrame.fileName ||
+            stackFrame.line === -1 ||
+            stackFrame.column === -1
+          ) {
+            return stackFrame.raw;
+          }
 
-        const relativePath = path.relative(process.cwd(), stackFrame.fileName);
-        if (relativePath.startsWith('dist/')) return relativePath;
-        const file = await fs.readFile(stackFrame.fileName, 'utf8');
-        const line = file.split('\n')[stackFrame.line - 1];
-        return `${relativePath}\n\n${line}\n${' '.repeat(
-          stackFrame.column - 1,
-        )}^`;
-      }),
-  );
+          const relativePath = path.relative(
+            process.cwd(),
+            stackFrame.fileName,
+          );
+          if (relativePath.startsWith('dist/')) return relativePath;
+          let file;
+          try {
+            file = await fs.readFile(stackFrame.fileName, 'utf8');
+          } catch {
+            return null;
+          }
+
+          const line = file.split('\n')[stackFrame.line - 1];
+          return `${relativePath}\n\n${line}\n${' '.repeat(
+            stackFrame.column - 1,
+          )}^`;
+        }),
+    )
+  ).filter(Boolean);
   return [`${error.name}: ${error.message}`, ...frames].join(
     `\n${'-'.repeat(55)}\n`,
   );

--- a/tests/utils/runJS.test.tsx
+++ b/tests/utils/runJS.test.tsx
@@ -106,7 +106,7 @@ test(
   }),
 );
 
-test.skip(
+test(
   'throws error with real source-mapped location',
   withBrowser(async ({ utils }) => {
     // Manually-thrown error
@@ -120,11 +120,11 @@ test.skip(
     expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
       "Error: errorFromTs
       -------------------------------------------------------
-      tests/utils/runJS.test.ts
+      tests/utils/runJS.test.tsx
 
               throw new Error('errorFromTs')\`,
                     ^"
-    `);
+      `);
 
     // Implicitly created error
     const error2 = await utils
@@ -137,21 +137,29 @@ test.skip(
     expect(await printErrorFrames(error2)).toMatchInlineSnapshot(`
       "ReferenceError: thisVariableDoesntExist is not defined
       -------------------------------------------------------
-      tests/utils/runJS.test.ts
+      tests/utils/runJS.test.tsx
 
               thisVariableDoesntExist\`,
               ^"
-    `);
-    // Syntax error
-    const error3 = await utils
-      .runJS(`console.log('hello)`)
-      .catch((error) => error);
+      `);
 
-    expect(await printErrorFrames(error3)).toMatchInlineSnapshot();
+    // Syntax error
+    const error3 = await utils.runJS(`asdf()}`).catch((error) => error);
+
+    expect(await printErrorFrames(error3)).toMatchInlineSnapshot(`
+      "TypeError: Failed to load runJS code (most likely due to a transpilation error)
+      -------------------------------------------------------
+      tests/utils/runJS.test.tsx
+
+          const error3 = await utils.runJS(\`asdf()}\`).catch((error) => error);
+                         ^
+      -------------------------------------------------------
+      dist/cjs/index.cjs"
+      `);
   }),
 );
 
-test.skip(
+test(
   'allows importing .tsx file, and errors from imported file are source mapped',
   withBrowser(async ({ utils, page }) => {
     await utils.runJS(`
@@ -185,11 +193,11 @@ test.skip(
         preactRender(<ThrowComponent />, document.body);
         ^
       -------------------------------------------------------
-      tests/utils/runJS.test.ts
+      tests/utils/runJS.test.tsx
 
               renderThrow()\`,
               ^"
-    `);
+      `);
   }),
 );
 


### PR DESCRIPTION
Now if code in `runJS` or `loadJS`, or imported by either of those, triggers an error, the error stack is source-mapped back to correct locations. Here's the [original PR](https://github.com/cloudfour/pleasantest/pull/17) that implemented this for the vite-based server. That PR has screenshots showing the feature.

The tests pretty well cover the feature so I don't think manual testing is needed.