### PR TITLE
Improve error message when Promise is passed into jest-dom matcher

### DIFF
--- a/.changeset/gentle-colts-pretend.md
+++ b/.changeset/gentle-colts-pretend.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Improve error message when Promise is passed into jest-dom matcher

--- a/src/extend-expect.ts
+++ b/src/extend-expect.ts
@@ -1,7 +1,12 @@
 import type { ElementHandle, JSHandle } from 'puppeteer';
 import { createClientRuntimeServer } from './module-server/client-runtime-server';
 import { deserialize, serialize } from './serialize';
-import { isPromise, jsHandleToArray, removeFuncFromStackTrace } from './utils';
+import {
+  isElementHandle,
+  isPromise,
+  jsHandleToArray,
+  removeFuncFromStackTrace,
+} from './utils';
 
 const methods = [
   'toBeInTheDOM',
@@ -45,11 +50,7 @@ expect.extend(
         ...matcherArgs: unknown[]
       ) {
         const serverPromise = createClientRuntimeServer();
-        if (
-          typeof elementHandle !== 'object' ||
-          // eslint-disable-next-line @cloudfour/typescript-eslint/no-unnecessary-condition
-          !elementHandle?.asElement?.()
-        ) {
+        if (!isElementHandle(elementHandle)) {
           // Special case: expect(null).not.toBeInTheDocument() should pass
           if (methodName === 'toBeInTheDocument' && this.isNot) {
             // This is actually passing but since it is isNot it has to return false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,10 @@ export const jsHandleToArray = async (arrayHandle: JSHandle) => {
   return arr;
 };
 
+export const isPromise = <T extends any>(
+  input: unknown | Promise<T>,
+): input is Promise<T> => Promise.resolve(input) === input; // https://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise/38339199#38339199
+
 export const assertElementHandle: (
   input: unknown,
   fn: (...params: any[]) => any,
@@ -25,11 +29,7 @@ export const assertElementHandle: (
   messageStart = `element must be an ElementHandle\n\n`,
 ) => {
   const type =
-    input === null
-      ? 'null'
-      : typeof input === 'object' && Promise.resolve(input) === input // https://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise/38339199#38339199
-      ? 'Promise'
-      : typeof input;
+    input === null ? 'null' : isPromise(input) ? 'Promise' : typeof input;
 
   if (type === 'Promise') {
     throw removeFuncFromStackTrace(

--- a/tests/extend-expect.test.ts
+++ b/tests/extend-expect.test.ts
@@ -1,0 +1,42 @@
+// The matcher test files cover most of the functionality.
+// This file checks behavior that is common to all matchers
+
+import { withBrowser } from 'pleasantest';
+
+test(
+  'throws useful error if Promise is passed',
+  withBrowser(async ({ screen, utils }) => {
+    await utils.injectHTML('<h1>Hi</h1>');
+    await expect(expect(screen.getByText('Hi')).toBeVisible()).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+                  "[2mexpect([22m[31mreceived[39m[2m).toBeVisible()[22m
+
+                  [31mreceived[39m value must be an HTMLElement or an SVGElement.
+                  Received a [31mPromise[39m. Did you forget to await?"
+              `);
+    // This short delay is necessary to make sure that the screen.getByText finishes before the test finishes
+    // Otherwise, the forgot await error is triggered
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }),
+);
+
+test(
+  'throws useful error if non-ElementHandle is passed',
+  withBrowser(async () => {
+    await expect(expect(null).toBeVisible()).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+                  "[2mexpect([22m[31mreceived[39m[2m).toBeVisible()[22m
+
+                  [31mreceived[39m value must be an HTMLElement or an SVGElement.
+                  Received has value: [31mnull[39m"
+              `);
+    await expect(expect({}).toBeVisible()).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "[2mexpect([22m[31mreceived[39m[2m).toBeVisible()[22m
+
+            [31mreceived[39m value must be an HTMLElement or an SVGElement.
+            Received has type:  object
+            Received has value: [31m{}[39m"
+          `);
+  }),
+);


### PR DESCRIPTION
If you do this:

```js
await expect(screen.getByText(/asdf/))
```

That code is wrong because the `getByText` query is not `await`ed.

Previously, the error message in that case was along the lines of `elementHandle.asElement is not a function`. Now the error message is:

<img width="426" alt="Screen Shot 2021-07-07 at 8 11 16 AM" src="https://user-images.githubusercontent.com/13206945/124784613-f21b5580-defa-11eb-9a92-fd5267e8a853.png">

