### PR TITLE
Refactor and improve browser stack trace printing

### DIFF
--- a/.changeset/tough-windows-sparkle.md
+++ b/.changeset/tough-windows-sparkle.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Refactor and improve browser stack trace printing

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,14 +349,13 @@ const createTab = async ({
       const mappedColumn = sourceLocation.column + 1;
       const mappedLine = sourceLocation.line;
       const mappedPath = sourceLocation.source || url.pathname;
-      const stackLine = printStackLine(
+      return printStackLine(
         // For the code frames, Jest will only recognize absolute paths
         path.join(process.cwd(), mappedPath),
         mappedLine,
         mappedColumn,
         stackItem.name,
       );
-      return stackLine;
     });
     const errorName = stack.slice(0, stack.indexOf(':')) || 'Error';
     const specializedErrors = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ import _ansiRegex from 'ansi-regex';
 import { fileURLToPath } from 'url';
 import type { PleasantestUser } from './user';
 import { pleasantestUser } from './user';
-import { assertElementHandle, removeFuncFromStackTrace } from './utils';
+import {
+  assertElementHandle,
+  printStackLine,
+  removeFuncFromStackTrace,
+} from './utils';
 import { createModuleServer } from './module-server';
 import { cleanupClientRuntimeServer } from './module-server/client-runtime-server';
 import { Console } from 'console';
@@ -311,7 +315,6 @@ const createTab = async ({
         'Failed to load runJS code (most likely due to a transpilation error)';
 
     const parsedStack = parseStackTrace(stack);
-    let isFirst = true;
     const modifiedStack = parsedStack.map(async (stackItem) => {
       if (stackItem.raw.startsWith(stack.slice(0, stack.indexOf('\n'))))
         return null;
@@ -325,7 +328,18 @@ const createTab = async ({
       const id = `.${url.pathname}`;
       const transformResult = requestCache.get(id);
       const map = typeof transformResult === 'object' && transformResult.map;
-      if (!map) return stackItem.raw;
+      if (!map) {
+        let p = url.pathname;
+        const npmPrefix = '/@npm/';
+        if (p.startsWith(npmPrefix))
+          p = path.join(
+            process.cwd(),
+            'node_modules',
+            p.slice(npmPrefix.length),
+          );
+        return printStackLine(p, line, column, stackItem.name);
+      }
+
       const { SourceMapConsumer } = await import('source-map');
       const consumer = await new SourceMapConsumer(map as any);
       const sourceLocation = consumer.originalPositionFor({ line, column });
@@ -335,20 +349,14 @@ const createTab = async ({
       const mappedColumn = sourceLocation.column + 1;
       const mappedLine = sourceLocation.line;
       const mappedPath = sourceLocation.source || url.pathname;
-      // If the stack frame has a name (i.e. function name), then display it
-      // _unless_ the stack frame is the first frame
-      // because if the function name is displayed in the first stack frame,
-      // then Jest cannot parse the stack trace to display the code frame
-      const location =
-        stackItem.name && !isFirst // Have to use isFirst instead of array loop index because function has early returns
-          ? `${stackItem.name} (${mappedPath}:${mappedLine}:${mappedColumn})`
-          : `${
-              // The first line has to be an absolute path,
-              // otherwise Jest won't recognize it for the code frame
-              isFirst ? path.join(process.cwd(), mappedPath) : mappedPath
-            }:${mappedLine}:${mappedColumn}`;
-      isFirst = false;
-      return `    at ${location}`;
+      const stackLine = printStackLine(
+        // For the code frames, Jest will only recognize absolute paths
+        path.join(process.cwd(), mappedPath),
+        mappedLine,
+        mappedColumn,
+        stackItem.name,
+      );
+      return stackLine;
     });
     const errorName = stack.slice(0, stack.indexOf(':')) || 'Error';
     const specializedErrors = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,3 +69,15 @@ export const removeFuncFromStackTrace = (
   Error.captureStackTrace(error, fn);
   return error;
 };
+
+export const printStackLine = (
+  path: string,
+  line: number,
+  column: number,
+  fnName?: string,
+) => {
+  const location = fnName
+    ? `${fnName} (${path}:${line}:${column})`
+    : `${path}:${line}:${column}`;
+  return `    at ${location}`;
+};


### PR DESCRIPTION
There are three changes to the way from-browser stack traces are printed now:

1. **Paths are always printed as absolute paths now**. Jest will only print the code frame for absolute paths. Previously, we were printing absolute paths for the lines that Jest would make code frames for, and relative paths otherwise. But that is more complicated and not necessary, because Jest will rewrite the absolute paths to relative paths anyways.
2. **URL's from node_modules get rewritten**. Previously, stack lines similar to `http://localhost:2345/@npm/react` would be printed as-is (since we don't generate source maps for node_modules). But when that happened, Jest would not be able to parse the stack trace (because it doesn't understand URL's, only file paths), and that would prevent it from displaying a code frame for _any_ line in the error. Now the `@npm` URL's get rewritten to absolute node_modules paths.
3. **Function names always are displayed if they exist**: Previously I had mistakenly thought that when function names (like `at FuncName (filePath:0:0)`) were one of the things that Jest's error stack parser was not able to recognize. It turns out that it _is_ able to recognize those, so now the code for conditionally displaying the function names depending on code frames has been removed.