### PR TITLE
Fix bug where css files in node_modules were pre-bundled

### DIFF
--- a/.changeset/wet-snails-unite.md
+++ b/.changeset/wet-snails-unite.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Fix bug where css files in node_modules were pre-bundled

--- a/src/module-server/middleware/js.ts
+++ b/src/module-server/middleware/js.ts
@@ -17,7 +17,7 @@ interface JSMiddlewareOpts {
 }
 
 // TODO: make this configurable
-const jsExts = /\.(?:[jt]sx?|[cm]js)$/;
+export const jsExts = /\.(?:[jt]sx?|[cm]js)$/;
 
 // Minimal version of https://github.com/preactjs/wmr/blob/main/packages/wmr/src/wmr-middleware.js
 

--- a/src/module-server/plugins/npm-plugin.ts
+++ b/src/module-server/plugins/npm-plugin.ts
@@ -9,6 +9,8 @@ import * as esbuild from 'esbuild';
 import { parse } from 'cjs-module-lexer';
 import MagicString from 'magic-string';
 import { fileURLToPath } from 'url';
+import { jsExts } from '../middleware/js';
+import { changeErrorMessage } from '../../utils';
 
 // This is the folder that Pleasantest is installed in (e.g. <something>/node_modules/pleasantest)
 const installFolder = dirname(dirname(dirname(fileURLToPath(import.meta.url))));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,6 +57,16 @@ export const assertElementHandle: (
   }
 };
 
+export const changeErrorMessage = (
+  error: Error,
+  changeMessage: (originalMessage: string) => string,
+) => {
+  const newMessage = changeMessage(error.message);
+  if (error.stack) error.stack = error.stack.replace(error.message, newMessage);
+  error.message = newMessage;
+  return error;
+};
+
 /**
  * Manipulate the stack trace and remove fn from it
  * That way jest will show a code frame from the user's code, not ours


### PR DESCRIPTION
When CSS files were imported, from node_modules (like `import '@reach/dialog/styles.css'`), the CSS file would get pre-bundled into a JS file, which was causing issues because when it got imported the 2nd time it would try to parse the JS file as a CSS file and convert it to JS a second time. This makes it so that for any non-JS files that are imported from node_modules, the pre-bundle step is skipped.