### PR TITLE
Allow throwing things other than errors within withBrowser

### DIFF
--- a/.changeset/kind-trainers-sleep.md
+++ b/.changeset/kind-trainers-sleep.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': minor
+---
+
+Allow throwing things other than errors within withBrowser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "pleasantest",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,9 @@ export const withBrowser: WithBrowser = (...args: any[]) => {
             }),
           );
         } else {
-          failureMessage.push(indent(error.message));
+          failureMessage.push(
+            indent(error instanceof Error ? error.message : String(error)),
+          );
         }
 
         await ctx.page.evaluate((...colorErr) => {


### PR DESCRIPTION
This is a super minor thing but sometimes for debugging I use the trick [shown here](https://github.com/cloudfour/pleasantest#withbrowser) (`throw new Error('leave the browser open')`) to leave the headed browser open even if the test passes. This is fine, but sometimes I want to type less, so I do `throw 0` which should have the same effect (makes the test fail so the browser says open). But there is a bug where Pleasantest expects anything thrown from the test to be an Error. This PR fixes that bug.