### PR TITLE
Node resolver: Refactor, add tests, and improve edge cases

### DIFF
--- a/.changeset/clean-gorillas-carry.md
+++ b/.changeset/clean-gorillas-carry.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Improve node_modules and relative paths resolution

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,10 @@ module.exports = {
     '^pleasantest$': '<rootDir>/dist/cjs/index.cjs',
   },
   testRunner: 'jest-circus/runner',
-  watchPathIgnorePatterns: ['<rootDir>/src/', '<rootDir>/.cache'],
+  watchPathIgnorePatterns: [
+    '<rootDir>/.cache',
+    '<rootDir>/src/.*(?<!\\.test)\\.ts',
+  ],
   transform: {
     '^.+\\.[jt]sx?$': ['esbuild-jest', { sourcemap: true }],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "pleasantest",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@testing-library/dom": "8.1.0",
         "@testing-library/jest-dom": "5.14.1",
         "@types/jest": "26.0.24",
-        "@types/node": "16.0.0",
+        "@types/node": "^12.20.16",
         "@types/polka": "0.5.3",
         "@types/puppeteer": "5.4.4",
         "ansi-regex": "6.0.0",
@@ -3791,12 +3791,6 @@
         "fs-extra": "^8.1.0"
       }
     },
-    "node_modules/@manypkg/find-root/node_modules/@types/node": {
-      "version": "12.20.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-      "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
-      "dev": true
-    },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -4432,9 +4426,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
+      "version": "12.20.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+      "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -24678,12 +24672,6 @@
         "fs-extra": "^8.1.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.20.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-          "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -25208,9 +25196,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
+      "version": "12.20.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+      "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@testing-library/dom": "8.1.0",
     "@testing-library/jest-dom": "5.14.1",
     "@types/jest": "26.0.24",
-    "@types/node": "16.0.0",
+    "@types/node": "^12.20.16",
     "@types/polka": "0.5.3",
     "@types/puppeteer": "5.4.4",
     "ansi-regex": "6.0.0",

--- a/src/module-server/bundle-npm-module.ts
+++ b/src/module-server/bundle-npm-module.ts
@@ -5,6 +5,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import { processGlobalPlugin } from './plugins/process-global-plugin';
 import * as esbuild from 'esbuild';
 import { parse } from 'cjs-module-lexer';
+// @ts-expect-error @types/node@12 doesn't like this import
 import { createRequire } from 'module';
 import { isBareImport, npmPrefix } from './extensions-and-detection';
 let npmCache: RollupCache | undefined;

--- a/src/module-server/bundle-npm-module.ts
+++ b/src/module-server/bundle-npm-module.ts
@@ -1,0 +1,117 @@
+import type { Plugin, RollupCache } from 'rollup';
+import { rollup } from 'rollup';
+import { promises as fs } from 'fs';
+import commonjs from '@rollup/plugin-commonjs';
+import { processGlobalPlugin } from './plugins/process-global-plugin';
+import * as esbuild from 'esbuild';
+import { parse } from 'cjs-module-lexer';
+import { createRequire } from 'module';
+import { isBareImport, npmPrefix } from './extensions-and-detection';
+let npmCache: RollupCache | undefined;
+
+/**
+ * Any package names in this set will need to have their named exports detected manually via require()
+ * because the export names cannot be statically analyzed
+ */
+const dynamicCJSModules = new Set(['prop-types', 'react-dom', 'react']);
+
+/**
+ * Bundle am npm module entry path into a single file
+ * @param mod The full path of the module to bundle, including subpackage/path
+ * @param id The imported identifier
+ * @param optimize Whether the bundle should be a minified/optimized bundle, or the default quick non-optimized bundle
+ */
+export const bundleNpmModule = async (
+  mod: string,
+  id: string,
+  optimize: boolean,
+) => {
+  let namedExports: string[] = [];
+  if (dynamicCJSModules.has(id)) {
+    let isValidCJS = true;
+    try {
+      const text = await fs.readFile(mod, 'utf8');
+      // Goal: Determine if it is ESM or CJS.
+      // Try to parse it with cjs-module-lexer, if it fails, assume it is ESM
+      // eslint-disable-next-line @cloudfour/typescript-eslint/await-thenable
+      await parse(text);
+    } catch {
+      isValidCJS = false;
+    }
+
+    if (isValidCJS) {
+      const require = createRequire(import.meta.url);
+      // eslint-disable-next-line @cloudfour/typescript-eslint/no-var-requires
+      const imported = require(mod);
+      if (typeof imported === 'object' && !imported.__esModule)
+        namedExports = Object.keys(imported);
+    }
+  }
+
+  const virtualEntry = '\0virtualEntry';
+  const hasSyntheticNamedExports = namedExports.length > 0;
+  const bundle = await rollup({
+    input: hasSyntheticNamedExports ? virtualEntry : mod,
+    cache: npmCache,
+    shimMissingExports: true,
+    treeshake: true,
+    preserveEntrySignatures: 'allow-extension',
+    plugins: [
+      hasSyntheticNamedExports &&
+        ({
+          // This plugin handles special-case packages whose named exports cannot be found via static analysis
+          // For these packages, the package is require()'d, and the named exports are determined that way.
+          // A virtual entry exports the named exports from the real entry package
+          name: 'cjs-named-exports',
+          resolveId(id) {
+            if (id === virtualEntry) return virtualEntry;
+          },
+          load(id) {
+            if (id === virtualEntry) {
+              const code = `export * from '${mod}'
+export {${namedExports.join(', ')}} from '${mod}'
+export { default } from '${mod}'`;
+              return code;
+            }
+          },
+        } as Plugin),
+      pluginNodeResolve(),
+      processGlobalPlugin({ NODE_ENV: 'development' }),
+      commonjs({
+        extensions: ['.js', '.cjs', ''],
+        sourceMap: false,
+        transformMixedEsModules: true,
+      }),
+      (optimize && {
+        name: 'esbuild-minify',
+        renderChunk: async (code) => {
+          const output = await esbuild.transform(code, {
+            minify: true,
+            legalComments: 'none',
+          });
+          return { code: output.code };
+        },
+      }) as Plugin,
+    ].filter(Boolean),
+  });
+  npmCache = bundle.cache;
+  const { output } = await bundle.generate({
+    format: 'es',
+    indent: false,
+    exports: 'named',
+    preferConst: true,
+  });
+
+  return output[0].code;
+};
+
+const pluginNodeResolve = (): Plugin => {
+  return {
+    name: 'node-resolve',
+    resolveId(id) {
+      if (isBareImport(id)) return { id: npmPrefix + id, external: true };
+      // If requests already have the npm prefix, mark them as external
+      if (id.startsWith(npmPrefix)) return { id, external: true };
+    },
+  };
+};

--- a/src/module-server/extensions-and-detection.ts
+++ b/src/module-server/extensions-and-detection.ts
@@ -1,0 +1,18 @@
+export const npmPrefix = '@npm/';
+
+export const isRelativeOrAbsoluteImport = (id: string) =>
+  id === '.' ||
+  id === '..' ||
+  id.startsWith('./') ||
+  id.startsWith('../') ||
+  id.startsWith('/');
+
+export const isBareImport = (id: string) =>
+  !(
+    isRelativeOrAbsoluteImport(id) ||
+    id.startsWith('\0') ||
+    id.startsWith(npmPrefix)
+  );
+
+export const cssExts = /\.(?:css|styl|stylus|s[ac]ss|less)$/;
+export const jsExts = /\.(?:[jt]sx?|[cm]js)$/;

--- a/src/module-server/index.ts
+++ b/src/module-server/index.ts
@@ -27,10 +27,7 @@ export const createModuleServer = async ({
   const plugins = [
     ...userPlugins,
     aliases && aliasPlugin({ entries: aliases }),
-    resolveExtensionsPlugin({
-      extensions: ['.ts', '.tsx', '.js', '.cjs'],
-      index: true,
-    }),
+    resolveExtensionsPlugin(),
     processGlobalPlugin({ NODE_ENV: 'development' }),
     npmPlugin({ root }),
     esbuildPlugin(),

--- a/src/module-server/middleware/css.ts
+++ b/src/module-server/middleware/css.ts
@@ -1,8 +1,9 @@
 import { posix, relative, resolve, sep } from 'path';
 import type polka from 'polka';
 import { promises as fs } from 'fs';
-import { cssExts, cssPlugin } from '../plugins/css';
+import { cssPlugin } from '../plugins/css';
 import type { PluginContext, TransformPluginContext } from 'rollup';
+import { cssExts } from '../extensions-and-detection';
 
 interface CSSMiddlewareOpts {
   root: string;

--- a/src/module-server/middleware/js.ts
+++ b/src/module-server/middleware/js.ts
@@ -9,15 +9,13 @@ import type {
   RawSourceMap,
 } from '@ampproject/remapping/dist/types/types';
 import MagicString from 'magic-string';
+import { jsExts } from '../extensions-and-detection';
 
 interface JSMiddlewareOpts {
   root: string;
   plugins: Plugin[];
   requestCache: Map<string, SourceDescription>;
 }
-
-// TODO: make this configurable
-export const jsExts = /\.(?:[jt]sx?|[cm]js)$/;
 
 // Minimal version of https://github.com/preactjs/wmr/blob/main/packages/wmr/src/wmr-middleware.js
 

--- a/src/module-server/node-resolve.test.ts
+++ b/src/module-server/node-resolve.test.ts
@@ -59,10 +59,11 @@ const createFs = async (input: string) => {
 };
 
 describe('resolving in node_modules', () => {
-  test('resolves main field', async () => {
+  test('resolves main field with higher priority than index.js', async () => {
     const fs = await createFs(`
       ./node_modules/foo/package.json {"main": "entry.js"}
       ./node_modules/foo/entry.js
+      ./node_modules/foo/index.js
     `);
     expect(await fs.resolve('foo')).toBe('./node_modules/foo/entry.js');
   });

--- a/src/module-server/node-resolve.test.ts
+++ b/src/module-server/node-resolve.test.ts
@@ -1,0 +1,218 @@
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, normalize, posix, sep } from 'path';
+import { changeErrorMessage } from '../utils';
+import { nodeResolve } from './node-resolve';
+
+const createdPaths: string[] = [];
+
+// Cleanup created files
+afterAll(async () => {
+  await Promise.all(
+    createdPaths.map(async (path) => {
+      await fs.rm(path, { recursive: true, force: true });
+    }),
+  );
+});
+
+const createFs = async (input: string) => {
+  const dir = await fs.mkdtemp(join(tmpdir(), 'pleasantest-create-fs-'));
+  createdPaths.push(dir);
+  const paths = input
+    .trim()
+    .split('\n')
+    .map((line) => {
+      const [, originalPath, contents] = /(\S*)(.*)/.exec(line.trim()) || [];
+      const path = normalize(
+        join(dir, originalPath.split(posix.sep).join(sep)),
+      );
+      return { path, contents };
+    });
+
+  await Promise.all(
+    paths.map(async ({ path, contents }) => {
+      await fs.mkdir(dirname(path), { recursive: true });
+      await fs.writeFile(path, contents || '');
+    }),
+  );
+
+  /** Replaces all instances of randomized tmp dir with "." */
+  const unrandomizePath = (text: string) => text.split(dir).join('.');
+
+  const resolve = async (id: string, { from }: { from?: string } = {}) => {
+    const result = await nodeResolve(
+      id,
+      join(dir, from || 'index.js'),
+      dir,
+    ).catch((error) => {
+      throw changeErrorMessage(error, (error) => unrandomizePath(error));
+    });
+    if (result)
+      return unrandomizePath(typeof result === 'string' ? result : result.path);
+  };
+
+  return { resolve };
+};
+
+describe('resolving in node_modules', () => {
+  test('resolves main field', async () => {
+    const fs = await createFs(`
+      ./node_modules/foo/package.json {"main": "entry.js"}
+      ./node_modules/foo/entry.js
+    `);
+    expect(await fs.resolve('foo')).toBe('./node_modules/foo/entry.js');
+  });
+
+  test('resolves index.js', async () => {
+    const fs = await createFs(`
+      ./node_modules/foo/package.json {}
+      ./node_modules/foo/index.js
+    `);
+    expect(await fs.resolve('foo')).toBe('./node_modules/foo/index.js');
+  });
+
+  test('resolves module field over main field and over index.js', async () => {
+    const fs = await createFs(`
+      ./node_modules/foo/package.json {"main": "index.js", "module": "index.esm.js"}
+      ./node_modules/foo/index.esm.js
+      ./node_modules/foo/index.js
+    `);
+    expect(await fs.resolve('foo')).toBe('./node_modules/foo/index.esm.js');
+  });
+
+  test('resolves exports field', async () => {
+    const fs = await createFs(`
+      ./node_modules/foo/package.json {"main": "index.js", "module": "index.esm.js", "exports": {".": "./index.exports.js"}}
+      ./node_modules/foo/index.exports.js
+      ./node_modules/foo/index.esm.js
+      ./node_modules/foo/index.js
+    `);
+    expect(await fs.resolve('foo')).toBe('./node_modules/foo/index.exports.js');
+  });
+
+  test('resolves subpath directly if exports field is not present', async () => {
+    const fs = await createFs(`
+      ./node_modules/foo/package.json {"main": "index.js"}
+      ./node_modules/foo/index.js
+      ./node_modules/foo/asdf.js
+    `);
+    expect(await fs.resolve('foo')).toBe('./node_modules/foo/index.js');
+    expect(await fs.resolve('foo/asdf')).toBe('./node_modules/foo/asdf.js');
+  });
+
+  test("refuses to resolve subpath if exports field is present and doesn't allow", async () => {
+    const fs = await createFs(`
+      ./node_modules/foo/package.json {"name": "foo", "main": "index.js", "exports": {".": "./index.js"}}
+      ./node_modules/foo/index.js
+      ./node_modules/foo/asdf.js
+    `);
+    expect(await fs.resolve('foo')).toBe('./node_modules/foo/index.js');
+    await expect(fs.resolve('foo/asdf')).rejects.toThrow(
+      'Missing "./asdf" export in "foo" package',
+    );
+  });
+
+  test('resolves subpath via exports field', async () => {
+    const fs = await createFs(`
+      ./node_modules/foo/package.json {"name": "foo", "main": "index.js", "exports": {"./asdf": "./dist/asdf.mjs"}}
+      ./node_modules/foo/dist/asdf.mjs
+    `);
+    expect(await fs.resolve('foo/asdf')).toEqual(
+      './node_modules/foo/dist/asdf.mjs',
+    );
+  });
+
+  test('resolves subpath via second package.json', async () => {
+    const fs = await createFs(`
+      ./node_modules/preact/package.json {}
+      ./node_modules/preact/index.js
+      ./node_modules/preact/hooks/package.json {"main": "../dist/hooks/index.js"}
+      ./node_modules/preact/dist/hooks/index.js
+    `);
+    expect(await fs.resolve('preact')).toBe('./node_modules/preact/index.js');
+    expect(await fs.resolve('preact/hooks')).toBe(
+      './node_modules/preact/dist/hooks/index.js',
+    );
+  });
+});
+
+describe('resolving relative paths', () => {
+  test('implicitly adds .js extension', async () => {
+    const fs = await createFs(`
+      ./other.js
+    `);
+    expect(await fs.resolve('./other')).toBe('./other.js');
+  });
+
+  test('implicitly adds .ts extension', async () => {
+    const fs = await createFs(`
+      ./other.ts
+    `);
+    expect(await fs.resolve('./other')).toBe('./other.ts');
+  });
+
+  test('implicitly adds .tsx extension', async () => {
+    const fs = await createFs(`
+      ./other.tsx
+    `);
+    expect(await fs.resolve('./other')).toBe('./other.tsx');
+  });
+
+  test('does not implicitly add .mjs or .cjs', async () => {
+    const fs = await createFs(`
+      ./other.mjs
+      ./other.cjs
+    `);
+    expect(await fs.resolve('./other')).toBe(undefined);
+  });
+
+  test('extensions can be loaded explicitly', async () => {
+    const fs = await createFs(`
+      ./other.mjs
+      ./other.cjs
+      ./other.js
+      ./other.jsx
+      ./other.ts
+      ./other.tsx
+    `);
+    expect(await fs.resolve('./other.mjs')).toBe('./other.mjs');
+    expect(await fs.resolve('./other.cjs')).toBe('./other.cjs');
+    expect(await fs.resolve('./other.js')).toBe('./other.js');
+    expect(await fs.resolve('./other.jsx')).toBe('./other.jsx');
+    expect(await fs.resolve('./other.ts')).toBe('./other.ts');
+    expect(await fs.resolve('./other.tsx')).toBe('./other.tsx');
+  });
+
+  test('implicitly resolves folder/index.js', async () => {
+    const fs = await createFs(`
+      ./folder/index.js
+    `);
+    expect(await fs.resolve('./folder')).toBe('./folder/index.js');
+  });
+
+  test('implicitly resolves folder/index.ts', async () => {
+    const fs = await createFs(`
+      ./folder/index.ts
+    `);
+    expect(await fs.resolve('./folder')).toBe('./folder/index.ts');
+  });
+
+  test('does not implicitly resolve folder/index.cjs or folder/index.mjs', async () => {
+    const fs = await createFs(`
+      ./folder/index.mjs
+      ./folder/index.cjs
+    `);
+    expect(await fs.resolve('./other')).toBe(undefined);
+  });
+
+  test('resolves folder with package.json in it with main/module field, and ignores exports field', async () => {
+    const fs = await createFs(`
+      ./folder/package.json {"main": "./cjs.js", "module": "./mjs.js", "exports": "./dont-use.js"}
+      ./folder/mjs.js
+    `);
+    expect(await fs.resolve('./folder')).toBe('./folder/mjs.js');
+  });
+});
+
+test.todo('LOAD_PACKAGE_SELF');
+test.todo('LOAD_PACKAGE_IMPORTS');

--- a/src/module-server/node-resolve.test.ts
+++ b/src/module-server/node-resolve.test.ts
@@ -10,7 +10,11 @@ const createdPaths: string[] = [];
 afterAll(async () => {
   await Promise.all(
     createdPaths.map(async (path) => {
-      await fs.rm(path, { recursive: true, force: true });
+      // For node 12, fs.rm() is not supported.
+      // For node 16, fs.rmdir() with recursive is deprecated (but still works)
+      // When we drop support for node 12, switch to below line for fs.rm()
+      await fs.rmdir(path, { recursive: true });
+      // Await fs.rm(path, { recursive: true, force: true });
     }),
   );
 });

--- a/src/module-server/node-resolve.ts
+++ b/src/module-server/node-resolve.ts
@@ -1,0 +1,184 @@
+// TODO before merge: See how to integrate with resolve-extensions-plugin:
+// './asdf' should look at package.json if ./asdf is a folder with package.json
+// './asdf' should also look for ./asdf/index.js
+
+import { dirname, join, posix, resolve as pResolve } from 'path';
+import { promises as fs } from 'fs';
+import { resolve, legacy as resolveLegacy } from 'resolve.exports';
+import {
+  isBareImport,
+  isRelativeOrAbsoluteImport,
+} from './extensions-and-detection';
+
+// Only used for node_modules
+const resolveCache = new Map<string, ResolveResult>();
+
+const resolveCacheKey = (id: string, root: string) => `${id}\0\0${root}`;
+
+/**
+ * Attempts to implement a combination of:
+ * - Node's CommonJS resolution algorithm: https://nodejs.org/api/modules.html#modules_all_together
+ * - Node's ESM resolution algorithm: https://nodejs.org/api/esm.html#esm_resolver_algorithm_specification
+ * - How people expect resolution to happen in webpack, rollup, and other tools
+ */
+export const nodeResolve = async (
+  id: string,
+  importer: string,
+  root: string,
+) => {
+  if (isBareImport(id)) return resolveFromNodeModules(id, root);
+  if (isRelativeOrAbsoluteImport(id))
+    return resolveRelativeOrAbsolute(id, importer);
+};
+
+const stat = (path: string) => fs.stat(path).catch(() => null);
+
+// Note: Node does not allow implicit extension resolution for .cjs or .mjs files
+// (it also doesn't do implicit extension resolution at all in modules, but it is so common because of bundlers, that we will support it)
+const exts = ['.js', '.ts', '.tsx', '.jsx'];
+
+export const resolveRelativeOrAbsolute = async (
+  id: string,
+  importer?: string,
+) => {
+  // LOAD_AS_FILE section in https://nodejs.org/api/modules.html#modules_all_together
+  const resolved = importer ? pResolve(dirname(importer), id) : id;
+  const result = await resolveAsFile(resolved);
+  if (result) return result;
+
+  // LOAD_AS_DIRECTORY section in https://nodejs.org/api/modules.html#modules_all_together
+  if ((await stat(resolved))?.isDirectory()) {
+    return resolveAsDirectory(resolved);
+  }
+};
+
+/** Given ./file, check for ./file.js (LOAD_AS_FILE) */
+const resolveAsFile = async (path: string) => {
+  if ((await stat(path))?.isFile()) return path;
+
+  for (const ext of exts) {
+    const stats = await stat(path + ext);
+    if (stats?.isFile()) return path + ext;
+  }
+};
+
+/** Given ./folder, check for ./folder/index.js (LOAD_INDEX) */
+const resolveIndex = async (directory: string) => {
+  const path = join(directory, 'index');
+  for (const ext of exts) {
+    const stats = await stat(path + ext);
+    if (stats?.isFile()) return path + ext;
+  }
+};
+
+const readPkgJson = async (directory: string) => {
+  const pkgJsonPath = join(directory, 'package.json');
+  if ((await stat(pkgJsonPath))?.isFile()) {
+    try {
+      return JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'));
+    } catch (error) {
+      throw new Error(
+        `Could not read or parse package.json at ${pkgJsonPath}: ${error.message}`,
+      );
+    }
+  }
+};
+
+const resolveAsDirectory = async (directory: string) => {
+  const pkgJson = await readPkgJson(directory);
+  if (pkgJson) {
+    // Node does not look at the "exports" field when importing a directory via a relative/absolute import.
+    // Node only uses the "exports" field when the import is a bare import
+    const main = readMainFields(pkgJson, '.', false);
+    if (main) {
+      const resolvedMain = pResolve(directory, main);
+      const result =
+        (await resolveAsFile(resolvedMain)) ||
+        (await resolveIndex(resolvedMain));
+      if (result) return result;
+    }
+  }
+
+  // Couldn't resolve via ./folder/package.json, so check for ./folder/index.js
+  return resolveIndex(directory);
+};
+
+interface ResolveResult {
+  path: string;
+  idWithVersion: string;
+}
+
+export const resolveFromNodeModules = async (
+  id: string,
+  root: string,
+): Promise<ResolveResult | undefined> => {
+  const cacheKey = resolveCacheKey(id, root);
+  const cached = resolveCache.get(cacheKey);
+  if (cached) return cached;
+  const pathChunks = id.split(posix.sep);
+  const isNpmNamespace = id[0] === '@';
+  // If it is an npm namespace, then get the first two folders, otherwise just one
+  const packageName = pathChunks.slice(0, isNpmNamespace ? 2 : 1);
+  // Path within imported module
+  const subPath = join(...pathChunks.slice(isNpmNamespace ? 2 : 1));
+
+  const pkgDir = join(root, 'node_modules', ...packageName);
+  const stats = await stat(pkgDir);
+  if (!stats || !stats.isDirectory())
+    throw new Error(
+      `Could not resolve ${id} from ${root}: ${pkgDir} ${
+        stats ? 'is not a directory' : 'does not exist'
+      }`,
+    );
+
+  const pkgJson = await readPkgJson(pkgDir);
+  const main = readMainFields(pkgJson, subPath, true);
+  let result;
+  if (main) result = join(pkgDir, main);
+  else if (!('exports' in pkgJson)) {
+    const fullPath = join(pkgDir, subPath);
+    result =
+      (await resolveAsFile(fullPath)) || (await resolveAsDirectory(fullPath));
+  }
+
+  if (result) {
+    const version = pkgJson.version;
+    const normalizedPkgName = packageName.join('__');
+    const idWithVersion = join(
+      version ? `${normalizedPkgName}@${version}` : normalizedPkgName,
+      subPath,
+    );
+    const resolved: ResolveResult = { path: result, idWithVersion };
+    resolveCache.set(cacheKey, resolved);
+    return resolved;
+  }
+};
+
+const readMainFields = (pkgJson: any, subPath: string, useExports: boolean) => {
+  if (useExports && 'exports' in pkgJson) {
+    return resolve(pkgJson, subPath, {
+      browser: true,
+      conditions: ['development', 'esmodules', 'module'],
+    });
+  }
+
+  let result;
+
+  if (subPath === '.')
+    result = resolveLegacy(pkgJson, {
+      browser: false,
+      fields: ['esmodules', 'modern', 'module', 'jsnext:main'],
+    });
+
+  if (!result)
+    result = (
+      resolveLegacy(pkgJson, {
+        browser: true,
+        fields: [],
+      }) as Record<string, string> | undefined
+    )?.[subPath];
+
+  if (!result && subPath === '.')
+    result = resolveLegacy(pkgJson, { browser: false, fields: ['main'] });
+  return result;
+};

--- a/src/module-server/node-resolve.ts
+++ b/src/module-server/node-resolve.ts
@@ -1,7 +1,3 @@
-// TODO before merge: See how to integrate with resolve-extensions-plugin:
-// './asdf' should look at package.json if ./asdf is a folder with package.json
-// './asdf' should also look for ./asdf/index.js
-
 import { dirname, join, posix, resolve as pResolve } from 'path';
 import { promises as fs } from 'fs';
 import { resolve, legacy as resolveLegacy } from 'resolve.exports';

--- a/src/module-server/plugins/css.ts
+++ b/src/module-server/plugins/css.ts
@@ -1,8 +1,8 @@
 import postcssPlugin from 'rollup-plugin-postcss';
 import { transformCssImports } from '../transform-css-imports';
 import { join } from 'path';
+import { cssExts } from '../extensions-and-detection';
 
-export const cssExts = /\.(?:css|styl|stylus|s[ac]ss|less)$/;
 export const cssPlugin = ({
   returnCSS = false,
 }: { returnCSS?: boolean } = {}) => {
@@ -25,7 +25,7 @@ export const cssPlugin = ({
         // Rewrites emitted url(...) and @imports to be relative to the project root.
         // Otherwise, relative paths don't work for injected stylesheets
         name: 'rewriteImports',
-        test: /\.(?:css|styl|stylus|s[ac]ss|less)$/,
+        test: cssExts,
         async process({ code, map }: { code: string; map?: string }) {
           code = await transformCssImports(code, this.id, {
             resolveId(specifier, id) {

--- a/src/module-server/plugins/npm-plugin.ts
+++ b/src/module-server/plugins/npm-plugin.ts
@@ -1,16 +1,11 @@
-import { dirname, join, normalize, posix } from 'path';
-import type { Plugin, RollupCache } from 'rollup';
-import { rollup } from 'rollup';
+import { dirname, join } from 'path';
+import type { Plugin } from 'rollup';
 import { promises as fs } from 'fs';
-import { resolve, legacy as resolveLegacy } from 'resolve.exports';
-import commonjs from '@rollup/plugin-commonjs';
-import { processGlobalPlugin } from './process-global-plugin';
-import * as esbuild from 'esbuild';
-import { parse } from 'cjs-module-lexer';
 import { fileURLToPath } from 'url';
-import { createRequire } from 'module';
-import { jsExts } from '../middleware/js';
+import { jsExts, isBareImport, npmPrefix } from '../extensions-and-detection';
 import { changeErrorMessage } from '../../utils';
+import { bundleNpmModule } from '../bundle-npm-module';
+import { resolveFromNodeModules } from '../node-resolve';
 
 // This is the folder that Pleasantest is installed in (e.g. <something>/node_modules/pleasantest)
 const installFolder = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
@@ -38,24 +33,13 @@ const getFromCache = async (cachePath: string) => {
   );
 };
 
-const isBareImport = (id: string) =>
-  !(
-    id === '.' ||
-    id.startsWith('\0') ||
-    id.startsWith('./') ||
-    id.startsWith('../') ||
-    id.startsWith('/') ||
-    id.startsWith(prefix)
-  );
-
-const prefix = '@npm/';
 export const npmPlugin = ({ root }: { root: string }): Plugin => {
   return {
     name: 'npm',
     // Rewrite bare imports to have @npm/ prefix
     async resolveId(id, importer) {
       if (!isBareImport(id)) return;
-      const resolved = await nodeResolve(id, root).catch((error) => {
+      const resolved = await resolveFromNodeModules(id, root).catch((error) => {
         throw importer
           ? changeErrorMessage(
               error,
@@ -63,18 +47,19 @@ export const npmPlugin = ({ root }: { root: string }): Plugin => {
             )
           : error;
       });
+      if (!resolved) return;
       if (!jsExts.test(resolved.path))
         // Don't pre-bundle, use the full path to the file in node_modules
         // (ex: CSS files in node_modules)
         return resolved.path;
 
-      return prefix + id;
+      return npmPrefix + id;
     },
     async load(id) {
-      if (!id.startsWith(prefix)) return null;
-      id = id.slice(prefix.length);
-      const resolved = await nodeResolve(id, root);
-      if (!jsExts.test(resolved.path)) return null; // Don't pre-bundle
+      if (!id.startsWith(npmPrefix)) return;
+      id = id.slice(npmPrefix.length);
+      const resolved = await resolveFromNodeModules(id, root);
+      if (!resolved) return;
       const cachePath = join(cacheDir, '@npm', `${resolved.idWithVersion}.js`);
       const cached = await getFromCache(cachePath);
       if (cached) return cached;
@@ -88,201 +73,3 @@ export const npmPlugin = ({ root }: { root: string }): Plugin => {
     },
   };
 };
-
-interface ResolveResult {
-  path: string;
-  idWithVersion: string;
-}
-
-const resolveFromFolder = async (
-  pkgDir: string,
-  subPath: string,
-  packageName: string[],
-): Promise<false | ResolveResult> => {
-  const pkgJsonPath = join(pkgDir, 'package.json');
-  let pkgJson;
-  try {
-    pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'));
-  } catch {
-    throw new Error(`Could not read or parse package.json at ${pkgJsonPath}`);
-  }
-
-  const version = pkgJson.version;
-  const idWithVersion = join(`${packageName.join('__')}@${version}`, subPath);
-
-  let result = resolve(pkgJson, subPath, {
-    browser: true,
-    conditions: ['development', 'esmodules', 'module'],
-  });
-
-  if (!result && subPath === '.')
-    result = resolveLegacy(pkgJson, {
-      browser: false,
-      fields: ['esmodules', 'modern', 'module', 'jsnext:main'],
-    });
-
-  if (!result)
-    result = (
-      resolveLegacy(pkgJson, {
-        browser: true,
-        fields: [],
-      }) as Record<string, string> | undefined
-    )?.[subPath];
-
-  if (!result && subPath === '.')
-    result = resolveLegacy(pkgJson, { browser: false, fields: ['main'] });
-
-  if (!result && !('exports' in pkgJson)) {
-    const extensions = ['.js', '/index.js', '.cjs', '/index.cjs'];
-    // If this was not conditionally included, this would have infinite recursion
-    if (subPath !== '.') extensions.unshift('');
-    for (const extension of extensions) {
-      const path = normalize(join(pkgDir, subPath) + extension);
-      const stats = await fs.stat(path).catch(() => null);
-      if (stats) {
-        if (stats.isFile()) return { path, idWithVersion };
-        if (stats.isDirectory()) {
-          // If you import some-package/foo and foo is a folder with a package.json in it,
-          // resolve main fields from the package.json
-          const result = await resolveFromFolder(path, '.', packageName);
-          if (result) return { path: result.path, idWithVersion };
-        }
-      }
-    }
-  }
-
-  if (!result) return false;
-  return { path: join(pkgDir, result), idWithVersion };
-};
-
-const resolveCache = new Map<string, ResolveResult>();
-
-const resolveCacheKey = (id: string, root: string) => `${id}\0\0${root}`;
-
-const nodeResolve = async (id: string, root: string) => {
-  const cacheKey = resolveCacheKey(id, root);
-  const cached = resolveCache.get(cacheKey);
-  if (cached) return cached;
-  const pathChunks = id.split(posix.sep);
-  const isNpmNamespace = id[0] === '@';
-  const packageName = pathChunks.slice(0, isNpmNamespace ? 2 : 1);
-  // If it is an npm namespace, then get the first two folders, otherwise just one
-  const pkgDir = join(root, 'node_modules', ...packageName);
-  await fs.stat(pkgDir).catch(() => {
-    throw new Error(`Could not resolve ${id} from ${root}`);
-  });
-  // Path within imported module
-  const subPath = join(...pathChunks.slice(isNpmNamespace ? 2 : 1));
-  const result = await resolveFromFolder(pkgDir, subPath, packageName);
-  if (result) {
-    resolveCache.set(cacheKey, result);
-    return result;
-  }
-
-  throw new Error(`Could not resolve ${id}`);
-};
-
-const pluginNodeResolve = (): Plugin => {
-  return {
-    name: 'node-resolve',
-    resolveId(id) {
-      if (isBareImport(id)) return { id: prefix + id, external: true };
-      // If requests already have the npm prefix, mark them as external
-      if (id.startsWith(prefix)) return { id, external: true };
-    },
-  };
-};
-
-let npmCache: RollupCache | undefined;
-
-/**
- * Bundle am npm module entry path into a single file
- * @param mod The full path of the module to bundle, including subpackage/path
- * @param id The imported identifier
- * @param optimize Whether the bundle should be a minified/optimized bundle, or the default quick non-optimized bundle
- */
-const bundleNpmModule = async (mod: string, id: string, optimize: boolean) => {
-  let namedExports: string[] = [];
-  if (dynamicCJSModules.has(id)) {
-    let isValidCJS = true;
-    try {
-      const text = await fs.readFile(mod, 'utf8');
-      // Goal: Determine if it is ESM or CJS.
-      // Try to parse it with cjs-module-lexer, if it fails, assume it is ESM
-      // eslint-disable-next-line @cloudfour/typescript-eslint/await-thenable
-      await parse(text);
-    } catch {
-      isValidCJS = false;
-    }
-
-    if (isValidCJS) {
-      const require = createRequire(import.meta.url);
-      // eslint-disable-next-line @cloudfour/typescript-eslint/no-var-requires
-      const imported = require(mod);
-      if (typeof imported === 'object' && !imported.__esModule)
-        namedExports = Object.keys(imported);
-    }
-  }
-
-  const virtualEntry = '\0virtualEntry';
-  const hasSyntheticNamedExports = namedExports.length > 0;
-  const bundle = await rollup({
-    input: hasSyntheticNamedExports ? virtualEntry : mod,
-    cache: npmCache,
-    shimMissingExports: true,
-    treeshake: true,
-    preserveEntrySignatures: 'allow-extension',
-    plugins: [
-      hasSyntheticNamedExports &&
-        ({
-          // This plugin handles special-case packages whose named exports cannot be found via static analysis
-          // For these packages, the package is require()'d, and the named exports are determined that way.
-          // A virtual entry exports the named exports from the real entry package
-          name: 'cjs-named-exports',
-          resolveId(id) {
-            if (id === virtualEntry) return virtualEntry;
-          },
-          load(id) {
-            if (id === virtualEntry) {
-              const code = `export * from '${mod}'
-export {${namedExports.join(', ')}} from '${mod}'
-export { default } from '${mod}'`;
-              return code;
-            }
-          },
-        } as Plugin),
-      pluginNodeResolve(),
-      processGlobalPlugin({ NODE_ENV: 'development' }),
-      commonjs({
-        extensions: ['.js', '.cjs', ''],
-        sourceMap: false,
-        transformMixedEsModules: true,
-      }),
-      (optimize && {
-        name: 'esbuild-minify',
-        renderChunk: async (code) => {
-          const output = await esbuild.transform(code, {
-            minify: true,
-            legalComments: 'none',
-          });
-          return { code: output.code };
-        },
-      }) as Plugin,
-    ].filter(Boolean),
-  });
-  npmCache = bundle.cache;
-  const { output } = await bundle.generate({
-    format: 'es',
-    indent: false,
-    exports: 'named',
-    preferConst: true,
-  });
-
-  return output[0].code;
-};
-
-/**
- * Any package names in this set will need to have their named exports detected manually via require()
- * because the export names cannot be statically analyzed
- */
-const dynamicCJSModules = new Set(['prop-types', 'react-dom', 'react']);

--- a/src/module-server/plugins/resolve-extensions-plugin.ts
+++ b/src/module-server/plugins/resolve-extensions-plugin.ts
@@ -1,135 +1,16 @@
-// Copied from https://github.com/preactjs/wmr/blob/c03abcc36c26dc936af8701ab9031ddff44995a5/packages/wmr/src/plugins/resolve-extensions-plugin.js
-
-/*
-  https://github.com/preactjs/wmr/blob/main/LICENSE
-  MIT License
-  Copyright (c) 2020 The Preact Authors
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-  */
-
-/*
-  Differences from original:
-  - Types
-  - Function style changed
-  - Comments changed
-  */
-
-import { promises as fs } from 'fs';
-import { resolve, dirname, join } from 'path';
 import type { Plugin } from 'rollup';
+import { isRelativeOrAbsoluteImport } from '../extensions-and-detection';
+import { resolveRelativeOrAbsolute } from '../node-resolve';
 
-const MAINFIELDS = ['module', 'main'];
-
-const fileExists = async (file: string) => {
-  try {
-    if ((await fs.stat(file)).isFile()) {
-      return true;
-    }
-  } catch {}
-
-  return false;
-};
-
-const fstat = async (file: string) => {
-  try {
-    return await fs.stat(file);
-  } catch {}
-
-  return false;
-};
-
-interface Options {
-  /** File extensions/suffixes to check for */
-  extensions: string[];
-  /** Also check for `/index.*` for all extensions */
-  index: boolean;
-  /** If set, checks for package.json main fields */
-  mainFields?: string[];
-}
-export const resolveExtensionsPlugin = ({
-  extensions,
-  index,
-  mainFields = MAINFIELDS,
-}: Options): Plugin => {
-  if (index) {
-    extensions = [...extensions, ...extensions.map((e) => `/index${e}`)];
-  }
-
+/**
+ * Handles resolving './foo' to './foo.js', and './foo/index.js', and resolving through './foo/package.json'
+ */
+export const resolveExtensionsPlugin = (): Plugin => {
   return {
     name: 'resolve-extensions-plugin',
     async resolveId(id, importer) {
-      if (id[0] === '\0') return;
-      if (/\.(tsx?|css|s[ac]ss|wasm)$/.test(id)) return;
-
-      let resolved;
-      try {
-        resolved = await this.resolve(id, importer, { skipSelf: true });
-      } catch {}
-
-      if (resolved) {
-        id = resolved.id;
-      } else if (importer) {
-        id = resolve(dirname(importer), id);
-      }
-
-      const stats = await fstat(id);
-      if (stats) {
-        // If the resolved specifier is a file, use it.
-        if (stats.isFile()) {
-          return id;
-        }
-
-        // Specifier resolved to a directory: look for package.json or ./index file
-        if (stats.isDirectory()) {
-          let pkgJson: string | undefined;
-          let pkg: any;
-          try {
-            pkgJson = await fs.readFile(resolve(id, 'package.json'), 'utf-8');
-          } catch {}
-
-          if (pkgJson) {
-            try {
-              pkg = JSON.parse(pkgJson);
-            } catch (error) {
-              console.warn(`Failed to parse package.json: ${id}\n  ${error}`);
-            }
-          }
-
-          if (pkg) {
-            const field = mainFields.find((f) => pkg[f]);
-            if (field) {
-              id = join(id, pkg[field]);
-              if (/\.([cm]?js|jsx?)$/.test(id)) {
-                return id;
-              }
-            } else {
-              // Package.json has an implicit "main" field of `index.js`:
-              id = join(id, 'index.js');
-            }
-          }
-        }
-      }
-
-      const p = id.replace(/\.[cm]?js$/, '');
-      for (const suffix of extensions) {
-        if (await fileExists(p + suffix)) {
-          return p + suffix;
-        }
-      }
+      if (!isRelativeOrAbsoluteImport(id)) return;
+      return resolveRelativeOrAbsolute(id, importer);
     },
   };
 };


### PR DESCRIPTION
Closes #155 

I went through https://nodejs.org/api/modules.html#modules_all_together, and tried to copy Node's commonJS resolution pretty closely.

Now the resolver is shared between the "extension resolver" and the "node modules resolver". Previously they did not share code, but since there is a lot of overlap, now they live in the same place and share code.

The "extension resolver" handles resolving `./asdf` to `./asdf.ts`, `./asdf/index.js`, and reading `./asdf/package.json` and resolving through there if it exists.

The "node modules resolver" handles resolving node_modules paths.