### PR TITLE
Throw module server errors from runJS

### DIFF
--- a/.changeset/funny-ghosts-dance.md
+++ b/.changeset/funny-ghosts-dance.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': minor
+---
+
+Improve error message output for resolution errors and syntax errors/transform errors

--- a/src/module-server/build-status-tracker.ts
+++ b/src/module-server/build-status-tracker.ts
@@ -1,5 +1,5 @@
 // This makes it so that errors thrown by the module server get re-thrown inside of runJS/loadJS.
-// This is necessary because the network is between runJS getting called and the module server, so errors do not propagate
+// This is necessary because the network is between the runJS call and the module server, so errors do not propagate
 // By tracking which runJS/loadJS initiated the request for each file, the module server can know which runJS/loadJS needs to reject.
 // When runJS finishes, it will check to see if the buildStatuses map has any errors corresponding to its buildId.
 // If there are any errors, it throws the first one.

--- a/src/module-server/build-status-tracker.ts
+++ b/src/module-server/build-status-tracker.ts
@@ -1,0 +1,37 @@
+// This makes it so that errors thrown by the module server get re-thrown inside of runJS/loadJS.
+// This is necessary because the network is between runJS getting called and the module server, so errors do not propagate
+// By tracking which runJS/loadJS initiated the request for each file, the module server can know which runJS/loadJS needs to reject.
+// When runJS finishes, it will check to see if the buildStatuses map has any errors corresponding to its buildId.
+// If there are any errors, it throws the first one.
+
+const buildStatuses = new Map<number, Error[]>();
+
+let buildIds = 0;
+
+/**
+ * Add an error for a specific buildId.
+ * If the build is already finished (resolved),
+ * triggers an uncaught rejection, with the hopes that it will fail the test.
+ */
+export const rejectBuild = (buildId: number, error: Error) => {
+  const statusArray = buildStatuses.get(buildId);
+  if (statusArray) statusArray.push(error);
+  // Uncaught promise rejection!
+  // Hope that Jest will catch it and fail the test, otherwise it is just logged by Node
+  else Promise.reject(error);
+};
+
+export const createBuildStatusTracker = () => {
+  const buildId = ++buildIds;
+  buildStatuses.set(buildId, []);
+  return {
+    buildId,
+    complete() {
+      const status = buildStatuses.get(buildId);
+      // This should never happen
+      if (!status) throw new Error('Build already completed');
+      buildStatuses.delete(buildId);
+      if (status.length > 0) return status;
+    },
+  };
+};

--- a/src/module-server/error-with-location.ts
+++ b/src/module-server/error-with-location.ts
@@ -1,0 +1,49 @@
+import * as colors from 'kolorist';
+import { createCodeFrame } from 'simple-code-frame';
+import { promises as fs } from 'fs';
+
+export class ErrorWithLocation extends Error {
+  filename?: string;
+  line: number;
+  column?: number;
+  constructor({
+    message,
+    filename,
+    line,
+    column,
+  }: {
+    message: string;
+    filename?: string;
+    line: number;
+    column?: number;
+  }) {
+    super(message);
+    this.filename = filename;
+    this.line = line;
+    this.column = column;
+  }
+
+  async toCodeFrame() {
+    if (!this.filename)
+      throw new Error('filename missing in ErrorWithLocation');
+
+    const originalCode = await fs.readFile(this.filename, 'utf8');
+    const frame = createCodeFrame(
+      originalCode,
+      this.line - 1,
+      this.column || 0,
+    );
+    const message = `${colors.red(this.message)}
+
+${colors.blue(
+  `${this.filename}:${this.line}${
+    this.column === undefined ? '' : `:${this.column + 1}`
+  }`,
+)}
+
+${frame}`;
+    const modifiedError = new Error(message);
+    modifiedError.stack = message;
+    return modifiedError;
+  }
+}

--- a/src/module-server/index.ts
+++ b/src/module-server/index.ts
@@ -48,7 +48,7 @@ export const createModuleServer = async ({
     else normalPlugins.push(plugin);
   }
 
-  const plugins: (Plugin | false | undefined)[] = [
+  const plugins: Plugin[] = [
     ...prePlugins,
 
     ...normalPlugins,
@@ -57,19 +57,19 @@ export const createModuleServer = async ({
     environmentVariablesPlugin(envVars),
     npmPlugin({ root, envVars }),
 
-    esbuildOptions && esbuildPlugin(esbuildOptions),
+    ...(esbuildOptions ? [esbuildPlugin(esbuildOptions)] : []),
     cssPlugin({ root }),
 
     ...postPlugins,
   ];
-  const filteredPlugins = plugins.filter(Boolean) as Plugin[];
   const requestCache = new Map<string, SourceDescription>();
   const middleware: polka.Middleware[] = [
     indexHTMLMiddleware,
-    jsMiddleware({ root, plugins: filteredPlugins, requestCache }),
+    jsMiddleware({ root, plugins, requestCache }),
     cssMiddleware({ root }),
     staticMiddleware({ root }),
   ];
+
   return {
     ...(await createServer({ middleware })),
     requestCache,

--- a/src/module-server/middleware/js.ts
+++ b/src/module-server/middleware/js.ts
@@ -15,10 +15,6 @@ import type {
 } from '@ampproject/remapping/dist/types/types';
 import MagicString from 'magic-string';
 import { jsExts } from '../extensions-and-detection';
-import * as esbuild from 'esbuild';
-import { createCodeFrame } from 'simple-code-frame';
-import * as colors from 'kolorist';
-import { Console } from 'console';
 import { rejectBuild } from '../build-status-tracker';
 import { ErrorWithLocation } from '../error-with-location';
 
@@ -27,6 +23,9 @@ interface JSMiddlewareOpts {
   plugins: Plugin[];
   requestCache: Map<string, SourceDescription>;
 }
+
+const getResolveCacheKey = (spec: string, from: string) =>
+  `${spec}%%FROM%%${from}`;
 
 // Minimal version of https://github.com/preactjs/wmr/blob/main/packages/wmr/src/wmr-middleware.js
 
@@ -46,9 +45,6 @@ export const jsMiddleware = ({
    * and syntax/transform errors will get thrown from the _first_ runJS/loadJS that they were imported from.
    */
   const resolveCache = new Map<string, ResolveCacheEntry>();
-
-  const getResolveCacheKey = (spec: string, from: string) =>
-    `${spec}%%FROM%%${from}`;
 
   const setInResolveCache = (
     spec: string,

--- a/src/module-server/plugins/npm-plugin.ts
+++ b/src/module-server/plugins/npm-plugin.ts
@@ -58,7 +58,6 @@ export const npmPlugin = ({
     if (!id.startsWith(npmPrefix)) return;
     id = id.slice(npmPrefix.length);
     const resolved = await resolveFromNodeModules(id, root);
-    if (!resolved) return;
 
     const cachePath = join(
       cacheDir,

--- a/src/module-server/plugins/npm-plugin.ts
+++ b/src/module-server/plugins/npm-plugin.ts
@@ -47,7 +47,6 @@ export const npmPlugin = ({
         ? changeErrorMessage(error, (msg) => `${msg} (imported by ${importer})`)
         : error;
     });
-    if (!resolved) return;
     if (!jsExts.test(resolved.path))
       // Don't pre-bundle, use the full path to the file in node_modules
       // (ex: CSS files in node_modules)

--- a/src/module-server/plugins/resolve-extensions-plugin.ts
+++ b/src/module-server/plugins/resolve-extensions-plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from '../plugin';
 import { isRelativeOrAbsoluteImport } from '../extensions-and-detection';
 import { resolveRelativeOrAbsolute } from '../node-resolve';
+import { changeErrorMessage } from '../../utils';
 
 /**
  * Handles resolving './foo' to './foo.js', and './foo/index.js', and resolving through './foo/package.json'
@@ -9,6 +10,10 @@ export const resolveExtensionsPlugin = (): Plugin => ({
   name: 'resolve-extensions-plugin',
   async resolveId(id, importer) {
     if (!isRelativeOrAbsoluteImport(id)) return;
-    return resolveRelativeOrAbsolute(id, importer);
+    return resolveRelativeOrAbsolute(id, importer).catch((error) => {
+      throw importer
+        ? changeErrorMessage(error, (msg) => `${msg} (imported by ${importer})`)
+        : error;
+    });
   },
 });

--- a/src/module-server/rollup-plugin-container.ts
+++ b/src/module-server/rollup-plugin-container.ts
@@ -47,13 +47,10 @@ import type {
 } from 'rollup';
 import type { Plugin } from './plugin';
 import { combineSourceMaps } from './combine-source-maps';
-import { createCodeFrame } from 'simple-code-frame';
 import type {
   DecodedSourceMap,
   RawSourceMap,
 } from '@ampproject/remapping/dist/types/types';
-import * as colors from 'kolorist';
-import { promises as fs } from 'fs';
 import { ErrorWithLocation } from './error-with-location';
 
 /** Fast splice(x,1) when order doesn't matter (h/t Rich) */

--- a/src/module-server/transform-imports.ts
+++ b/src/module-server/transform-imports.ts
@@ -31,10 +31,11 @@
   */
 
 import { parse } from 'es-module-lexer';
-import { createCodeFrame } from 'simple-code-frame';
-import * as colors from 'kolorist';
-import { cssExts, jsExts } from './extensions-and-detection';
-import { extname } from 'path';
+import { ErrorWithLocation } from './error-with-location';
+import type {
+  DecodedSourceMap,
+  RawSourceMap,
+} from '@ampproject/remapping/dist/types/types';
 
 type MaybePromise<T> = Promise<T> | T;
 type ResolveFn = (
@@ -54,6 +55,7 @@ interface Options {
 export const transformImports = async (
   code: string,
   id: string,
+  map: string | DecodedSourceMap | RawSourceMap,
   { resolveImportMeta, resolveId, resolveDynamicImport }: Options = {},
 ) => {
   let imports;
@@ -65,22 +67,25 @@ export const transformImports = async (
     const linesUntilError = code.slice(0, error.idx).split('\n');
     const line = linesUntilError.length;
     const column = linesUntilError[linesUntilError.length - 1].length;
-    const frame = createCodeFrame(code, line - 1, column);
-    let message = `${colors.red(colors.bold(error.message))}
+    const modifiedError = new ErrorWithLocation({
+      message: `Error parsing module with es-module-lexer`,
+      line,
+      column,
+      filename: id,
+    });
 
-${colors.red(`${id}:${line}:${column + 1}`)}
-
-${frame}
-`;
-    if (!jsExts.test(id) && !cssExts.test(id))
-      message += `${colors.yellow(
-        `You may need to add plugins to the module server to handle ${
-          extname(id) ? `${extname(id)} files` : id
-        }`,
-      )}\n`;
-
-    const modifiedError = new Error(message);
-    modifiedError.stack = message;
+    if (map) {
+      const { SourceMapConsumer } = await import('source-map');
+      const consumer = await new SourceMapConsumer(map as any);
+      const sourceLocation = consumer.originalPositionFor({ line, column });
+      consumer.destroy();
+      if (sourceLocation.line !== null) {
+        modifiedError.line = sourceLocation.line;
+        modifiedError.column =
+          sourceLocation.column === null ? undefined : sourceLocation.column;
+      }
+      modifiedError.filename = sourceLocation.source || id;
+    }
     throw modifiedError;
   }
 

--- a/src/module-server/transform-imports.ts
+++ b/src/module-server/transform-imports.ts
@@ -55,7 +55,7 @@ interface Options {
 export const transformImports = async (
   code: string,
   id: string,
-  map: string | DecodedSourceMap | RawSourceMap,
+  map: string | DecodedSourceMap | RawSourceMap | undefined,
   { resolveImportMeta, resolveId, resolveDynamicImport }: Options = {},
 ) => {
   let imports;

--- a/tests/utils/external-with-syntax-error.ts
+++ b/tests/utils/external-with-syntax-error.ts
@@ -1,1 +1,2 @@
+// @ts-expect-error: this is intentionally invalid
 const someVariable: string;

--- a/tests/utils/external-with-syntax-error.ts
+++ b/tests/utils/external-with-syntax-error.ts
@@ -1,0 +1,1 @@
+const someVariable: string;

--- a/tests/utils/runJS.test.tsx
+++ b/tests/utils/runJS.test.tsx
@@ -268,19 +268,19 @@ test(
 
     await expect(formatErrorWithCodeFrame(runPromise)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-                    "[esbuild] Expected \\";\\" but found \\")\\"
+        "[esbuild] Expected \\";\\" but found \\")\\"
 
-                    <root>/tests/utils/runJS.test.tsx:###:###
+        <root>/tests/utils/runJS.test.tsx:###:###
 
-                      ### |   withBrowser(async ({ utils }) => {
-                      ### |     const runPromise = utils.runJS(\`
-                    > ### |       console.log('hi'))
-                          |                        ^
-                      ### |     \`);
-                      ### | 
-                      ### |     await expect(formatErrorWithCodeFrame(runPromise)).rejects
-                    "
-                `);
+          ### |   withBrowser(async ({ utils }) => {
+          ### |     const runPromise = utils.runJS(\`
+        > ### |       console.log('hi'))
+              |                        ^
+          ### |     \`);
+          ### | 
+          ### |     await expect(formatErrorWithCodeFrame(runPromise)).rejects
+        "
+      `);
   }),
 );
 

--- a/tests/utils/runJS.test.tsx
+++ b/tests/utils/runJS.test.tsx
@@ -3,6 +3,7 @@ import type { PleasantestContext, PleasantestUtils } from 'pleasantest';
 import { printErrorFrames } from '../test-utils';
 import vuePlugin from 'rollup-plugin-vue';
 import aliasPlugin from '@rollup/plugin-alias';
+import ansiRegex from 'ansi-regex';
 
 const createHeading = async ({
   utils,
@@ -144,21 +145,51 @@ test(
               thisVariableDoesntExist\`,
               ^"
       `);
-
-    // Syntax error
-    const error3 = await utils.runJS(`asdf()}`).catch((error) => error);
-
-    expect(await printErrorFrames(error3)).toMatchInlineSnapshot(`
-      "TypeError: Failed to load runJS code (most likely due to a transpilation error)
-      -------------------------------------------------------
-      tests/utils/runJS.test.tsx
-
-          const error3 = await utils.runJS(\`asdf()}\`).catch((error) => error);
-                         ^
-      -------------------------------------------------------
-      dist/cjs/index.cjs"
-      `);
   }),
+);
+
+test(
+  'Imports by different runJS calls point to the same values',
+  withBrowser(async ({ utils }) => {
+    await utils.runJS(`
+      import { render } from 'preact'
+      window.__preact_render = render
+    `);
+    await utils.runJS(`
+      import { render } from 'preact'
+      if (window.__preact_render !== render)
+        throw new Error('Importing the same thing multiple times resulted in different modules')
+    `);
+  }),
+);
+
+test(
+  "TransformImports throws stack frame if it can't parse the input",
+  withBrowser(
+    // Disable esbuild so that the invalid code will get through to the import transformer
+    { moduleServer: { esbuild: false } },
+    async ({ utils }) => {
+      const runPromise = utils.runJS(`
+        asdf())
+      `);
+
+      await expect(formatErrorWithCodeFrame(runPromise)).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+          "Error parsing module with es-module-lexer
+
+          <root>/tests/utils/runJS.test.tsx:###:###
+
+            ### |     async ({ utils }) => {
+            ### |       const runPromise = utils.runJS(\`
+          > ### |         asdf())
+                |               ^
+            ### |       \`);
+            ### | 
+            ### |       await expect(formatErrorWithCodeFrame(runPromise)).rejects
+          "
+        `);
+    },
+  ),
 );
 
 test(
@@ -203,13 +234,106 @@ test(
   }),
 );
 
-test.todo(
-  'if an imported file has a syntax error the location is source mapped',
+const stripAnsi = (input: string) => input.replace(ansiRegex(), '');
+
+const removeLineNumbers = (input: string) => {
+  const lineRegex = /^(\s*>?\s*)(\d+)/gm;
+  const fileRegex = new RegExp(`${process.cwd()}([a-zA-Z/._-]*)[\\d:]*`, 'g');
+  // console.log('remove line numbers', input, input.replace(lineRegex, ''));
+  return (
+    input
+      .replace(
+        lineRegex,
+        (_match, whitespace, numbers) =>
+          `${whitespace}${'#'.repeat(numbers.length)}`,
+      )
+      // Take out the file paths so the tests will pass on more than 1 person's machine
+      .replace(fileRegex, '<root>$1:###:###')
+  );
+};
+
+const formatErrorWithCodeFrame = <T extends any>(input: Promise<T>) =>
+  input.catch((error) => {
+    error.message = removeLineNumbers(stripAnsi(error.message));
+    error.stack = removeLineNumbers(stripAnsi(error.stack));
+    throw error;
+  });
+
+test(
+  'If the code string has a syntax error the location is source mapped',
+  withBrowser(async ({ utils }) => {
+    const runPromise = utils.runJS(`
+      console.log('hi'))
+    `);
+
+    await expect(formatErrorWithCodeFrame(runPromise)).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+        "[esbuild] Expected \\";\\" but found \\")\\"
+
+        <root>/tests/utils/runJS.test.tsx:###:###
+
+          ### |   withBrowser(async ({ utils }) => {
+          ### |     const runPromise = utils.runJS(\`
+        > ### |       console.log('hi'))
+              |                        ^
+          ### |     \`);
+          ### | 
+          ### |     await expect(formatErrorWithCodeFrame(runPromise)).rejects
+        "
+      `);
+  }),
 );
-test.todo(
-  'if the code string has a syntax error the location is source mapped',
+
+test(
+  'If an imported file has a syntax error the location is source mapped',
+  withBrowser(async ({ utils }) => {
+    const runPromise = utils.runJS(`
+      import './external-with-syntax-error'
+    `);
+
+    await expect(formatErrorWithCodeFrame(runPromise)).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+        "[esbuild] The constant \\"someVariable\\" must be initialized
+
+        <root>/tests/utils/external-with-syntax-error.ts:###:###
+
+        > # | const someVariable: string;
+            |       ^
+          # | 
+        "
+      `);
+  }),
 );
-test.todo('resolution error if a package does not exist in node_modules');
+
+test(
+  'resolution error if a package does not exist in node_modules',
+  withBrowser(async ({ utils }) => {
+    const runPromise = formatErrorWithCodeFrame(
+      utils.runJS(`
+        import { foo } from 'something-not-existing'
+      `),
+    );
+
+    await expect(runPromise).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not find something-not-existing in node_modules (imported by <root>/tests/utils/runJS.test.tsx:###:###)"`,
+    );
+  }),
+);
+
+test(
+  'resolution error if a relative path does not exist',
+  withBrowser(async ({ utils }) => {
+    const runPromise = utils.runJS(`
+      import { foo } from './bad-relative-path'
+    `);
+
+    await expect(
+      formatErrorWithCodeFrame(runPromise),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not resolve ./bad-relative-path (imported by <root>/tests/utils/runJS.test.tsx:###:###)"`,
+    );
+  }),
+);
 
 test(
   'Allows importing CSS into JS file',
@@ -224,9 +348,9 @@ test(
   }),
 );
 
-describe('CJS interop edge cases', () => {
+describe('Ecosystem interoperability', () => {
   test(
-    'Named exports implicitly created from default-only export',
+    'Named exports implicitly created from default-only export in CJS',
     withBrowser(async ({ utils }) => {
       // Prop-types is CJS and provides non-statically-analyzable named exports
       await utils.runJS(`

--- a/tests/utils/runJS.test.tsx
+++ b/tests/utils/runJS.test.tsx
@@ -175,19 +175,19 @@ test(
 
       await expect(formatErrorWithCodeFrame(runPromise)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-          "Error parsing module with es-module-lexer
+                        "Error parsing module with es-module-lexer
 
-          <root>/tests/utils/runJS.test.tsx:###:###
+                        <root>/tests/utils/runJS.test.tsx:###:###
 
-            ### |     async ({ utils }) => {
-            ### |       const runPromise = utils.runJS(\`
-          > ### |         asdf())
-                |               ^
-            ### |       \`);
-            ### | 
-            ### |       await expect(formatErrorWithCodeFrame(runPromise)).rejects
-          "
-        `);
+                          ### |     async ({ utils }) => {
+                          ### |       const runPromise = utils.runJS(\`
+                        > ### |         asdf())
+                              |               ^
+                          ### |       \`);
+                          ### | 
+                          ### |       await expect(formatErrorWithCodeFrame(runPromise)).rejects
+                        "
+                    `);
     },
   ),
 );
@@ -268,19 +268,19 @@ test(
 
     await expect(formatErrorWithCodeFrame(runPromise)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-        "[esbuild] Expected \\";\\" but found \\")\\"
+                    "[esbuild] Expected \\";\\" but found \\")\\"
 
-        <root>/tests/utils/runJS.test.tsx:###:###
+                    <root>/tests/utils/runJS.test.tsx:###:###
 
-          ### |   withBrowser(async ({ utils }) => {
-          ### |     const runPromise = utils.runJS(\`
-        > ### |       console.log('hi'))
-              |                        ^
-          ### |     \`);
-          ### | 
-          ### |     await expect(formatErrorWithCodeFrame(runPromise)).rejects
-        "
-      `);
+                      ### |   withBrowser(async ({ utils }) => {
+                      ### |     const runPromise = utils.runJS(\`
+                    > ### |       console.log('hi'))
+                          |                        ^
+                      ### |     \`);
+                      ### | 
+                      ### |     await expect(formatErrorWithCodeFrame(runPromise)).rejects
+                    "
+                `);
   }),
 );
 
@@ -293,15 +293,16 @@ test(
 
     await expect(formatErrorWithCodeFrame(runPromise)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-        "[esbuild] The constant \\"someVariable\\" must be initialized
+            "[esbuild] The constant \\"someVariable\\" must be initialized
 
-        <root>/tests/utils/external-with-syntax-error.ts:###:###
+            <root>/tests/utils/external-with-syntax-error.ts:###:###
 
-        > # | const someVariable: string;
-            |       ^
-          # | 
-        "
-      `);
+              # | // @ts-expect-error: this is intentionally invalid
+            > # | const someVariable: string;
+                |       ^
+              # | 
+            "
+          `);
   }),
 );
 

--- a/tests/utils/runJS.test.tsx
+++ b/tests/utils/runJS.test.tsx
@@ -239,7 +239,6 @@ const stripAnsi = (input: string) => input.replace(ansiRegex(), '');
 const removeLineNumbers = (input: string) => {
   const lineRegex = /^(\s*>?\s*)(\d+)/gm;
   const fileRegex = new RegExp(`${process.cwd()}([a-zA-Z/._-]*)[\\d:]*`, 'g');
-  // console.log('remove line numbers', input, input.replace(lineRegex, ''));
   return (
     input
       .replace(


### PR DESCRIPTION
Closes #156

Here's how it looks now!

<img width="695" alt="Screen Shot 2021-07-28 at 3 52 37 PM" src="https://user-images.githubusercontent.com/13206945/127406408-0cab2d1a-1092-4b07-a72a-e9da47e8d6be.png">

## Description

From #156:

> If I do:
> 
> ```js
> await utils.runJS(`
>   console.log('tooManyParens'))
> `)
> ```
> then ESBuild throws a parse error, which gets caught and displayed in the console, and the runJS will also throw because the HTTP server returned a 500 for the module.

There are several problems with this:
- The actual error message that we care about is just logged to the console, so we can't make tests that the error message is correct
- There are two error messages displayed, and the one displayed more prominently is the unimportant one from the browser saying that there was a 500 response for a module

This PR solves this problem, the comment inside the build status tracker file explains how:

> This makes it so that errors thrown by the module server get re-thrown inside of runJS/loadJS.
> This is necessary because the network is between runJS getting called and the module server, so errors do not propagate
> By tracking which runJS/loadJS initiated the request for each file, the module server can know which runJS/loadJS needs to reject.
> When runJS finishes, it will check to see if the buildStatuses map has any errors corresponding to its buildId.
> If there are any errors, it throws the first one.

We keep track of which files were requested by which runJS using build ID's, which are injected into query parameters, i.e.:

`runJS("import './something'")`

`something.ts?build-id=1`
```ts
import {render} from '/@npm/preact?build-id=1'
import {something} from './asdf.js?build-id=1'
```

Each time runJS is called, it gets a new build ID. The build ids propagate all through the module graph (i.e. when it serves `./asdf.js?build-id=1`, the build id query parameter will get attached to every import in _that_ file).

`runJS("import './something-else'")`

`something-else.ts?build-id=2`
```ts
import {render} from '/@npm/preact?build-id=1' // you would expect this to be build-id=2 but it can't be
import {somethingElse} from './asdf2.js?build-id=2'
```

When something gets imported that was already imported in a previous build, the previous buildId gets reused. This is important because it is necessary that the browser returns a cached instance of the module from the module cache, rather than creating a new instance (which will happen if the query parameters change). For many modules, preact included, if there are multiple instances active, there will be bugs. So by reusing the previous build ID, we can fix this problem.

Other things happening in this PR:

The same createCodeFrame code is not repeated all over the place anymore. Now it is in just one place: the ErrorWithLocation class. This makes things a lot easier and more consistent.

I changed node-resolve to throw more useful error messages in more cases instead of undefined. Look at the node-resolve tests to see the specific changes.

Also note: None of the error-handling changes apply to loadJS, only to runJS for now. https://github.com/cloudfour/pleasantest/issues/175 covers making them share the logic so they both get all the benefits of this.