### PR TITLE
Fix column offsets for source mapped code

### DIFF
--- a/.changeset/seven-fireants-shop.md
+++ b/.changeset/seven-fireants-shop.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Fix column offsets when esbuild is disabled

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,17 +357,18 @@ const createTab = async ({
 
       const { SourceMapConsumer } = await import('source-map');
       const consumer = await new SourceMapConsumer(map as any);
-      const sourceLocation = consumer.originalPositionFor({ line, column });
+      const sourceLocation = consumer.originalPositionFor({
+        line,
+        column: column - 1, // Source-map uses zero-based column numbers
+      });
       consumer.destroy();
-      if (sourceLocation.line === null || sourceLocation.column === null)
-        return stackItem.raw;
-      const mappedColumn = sourceLocation.column + 1;
-      const mappedLine = sourceLocation.line;
-      const mappedPath = sourceLocation.source || url.pathname;
       return printStackLine(
-        mappedPath,
-        mappedLine,
-        mappedColumn,
+        join(process.cwd(), url.pathname),
+        sourceLocation.line ?? line,
+        sourceLocation.column === null
+          ? column
+          : // Convert back from zero-based column to 1-based
+            sourceLocation.column + 1,
         stackItem.name,
       );
     });

--- a/src/module-server/index.ts
+++ b/src/module-server/index.ts
@@ -66,7 +66,7 @@ export const createModuleServer = async ({
   const requestCache = new Map<string, SourceDescription>();
   const middleware: polka.Middleware[] = [
     indexHTMLMiddleware,
-    jsMiddleware({ root, plugins: filteredPlugins, requestCache }),
+    await jsMiddleware({ root, plugins: filteredPlugins, requestCache }),
     cssMiddleware({ root }),
     staticMiddleware({ root }),
   ];

--- a/src/module-server/middleware/js.ts
+++ b/src/module-server/middleware/js.ts
@@ -24,14 +24,15 @@ interface JSMiddlewareOpts {
 
 // Minimal version of https://github.com/preactjs/wmr/blob/main/packages/wmr/src/wmr-middleware.js
 
-export const jsMiddleware = ({
+export const jsMiddleware = async ({
   root,
   plugins,
   requestCache,
-}: JSMiddlewareOpts): polka.Middleware => {
+}: JSMiddlewareOpts): Promise<polka.Middleware> => {
   const rollupPlugins = createPluginContainer(plugins);
 
-  rollupPlugins.buildStart();
+  await rollupPlugins.options();
+  await rollupPlugins.buildStart();
 
   return async (req, res, next) => {
     try {

--- a/src/module-server/plugins/esbuild-plugin.ts
+++ b/src/module-server/plugins/esbuild-plugin.ts
@@ -24,6 +24,7 @@ export const esbuildPlugin = (
         ...esbuildOptions,
       })
       .catch((error) => {
+        if (!('errors' in error)) throw error;
         const err = error.errors[0];
         this.error(err.text, {
           line: err.location.line,

--- a/src/module-server/rollup-plugin-container.ts
+++ b/src/module-server/rollup-plugin-container.ts
@@ -36,6 +36,7 @@
   - relative resolution fixed to handle '.' for ctx.resolveId
   - Source map handling added to transform hook
   - Error handling (with code frame, using source maps) added to transform hook
+  - Stubbed out options hook was added
   */
 
 import { resolve, dirname } from 'path';
@@ -232,11 +233,9 @@ export const createPluginContainer = (plugins: Plugin[]) => {
     ) {
       let code = originalCode;
       // TODO: if any of the transforms is missing sourcemaps, then there should be no source maps emitted
-      const sourceMaps: (DecodedSourceMap | RawSourceMap)[] = [];
-      if (inputMap)
-        sourceMaps.push(
-          typeof inputMap === 'string' ? JSON.parse(inputMap) : inputMap,
-        );
+      const sourceMaps: (DecodedSourceMap | RawSourceMap)[] = inputMap
+        ? [typeof inputMap === 'string' ? JSON.parse(inputMap) : inputMap]
+        : [];
       for (plugin of plugins) {
         if (!plugin.transform) continue;
         try {
@@ -302,6 +301,14 @@ ${frame}`;
         code,
         map: combineSourceMaps(id, sourceMaps),
       };
+    },
+
+    async options() {
+      for (plugin of plugins) {
+        // Since we don't have "input options", we just pass {}
+        // This hook must be called for @rollup/plugin-babel
+        await plugin.options?.call(ctx as any, {});
+      }
     },
 
     async load(id: string): Promise<LoadResult> {


### PR DESCRIPTION
Closes #189 

The problem was, the column offsets were off-by-one when esbuild was disabled, but they were fine when esbuild was enabled.

Something like this:

```
console.log(nothing)
             ^ ReferenceError: nothing is not defined
```

The reason for this ended up being that [the `source-map` library](https://github.com/mozilla/source-map) uses zero-indexed columns, while almost everything else uses 1-indexed columns. Once I found this out it was easy to fix.

Along the way, I found out that `@rollup/plugin-babel` doesn't work, so I fixed it (the plugin required that the `options` hook got called, so I added the `options` hook to our fake rollup). I think it is important for this plugin to work since it will probably be pretty common for people to a specific babel setup that can't be replaced with esbuild

The tests cover both changes ✅ 