### PR TITLE
Improve forgot-await detection by tracking async calls

### DIFF
--- a/.changeset/chilled-mails-eat.md
+++ b/.changeset/chilled-mails-eat.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': minor
+---
+
+Improve forgot-await detection

--- a/src/async-hooks.ts
+++ b/src/async-hooks.ts
@@ -1,0 +1,61 @@
+/**
+ * Manages asynchronous calls within withBrowser.
+ * If any async calls are "left over" when withBrowser finishes executing,
+ * then that means the user forgot to await the async calls,
+ * so we should throw an error that indicates that.
+ */
+
+import { removeFuncFromStackTrace } from './utils';
+
+/**
+ * Set of all active async hook trackers
+ * We need to store this module-level so that jest-dom matchers can know which withBrowser they "belong" to
+ * If there are multiple active at a time, the jest-dom matchers won't include the forgot-await behavior.
+ */
+export const activeAsyncHookTrackers = new Set<AsyncHookTracker>();
+
+export interface AsyncHookTracker {
+  addHook<T extends unknown>(
+    func: () => Promise<T>,
+    captureFunction: (...args: any[]) => any,
+  ): Promise<T | undefined>;
+  close(): Error | undefined;
+}
+
+export const createAsyncHookTracker = (): AsyncHookTracker => {
+  const hooks = new Set<Error>();
+  let isClosed = false;
+
+  const addHook: AsyncHookTracker['addHook'] = async (
+    func,
+    captureFunction,
+  ) => {
+    const forgotAwaitError = new Error(
+      'Cannot interact with browser after test finishes. Did you forget to await?',
+    );
+    removeFuncFromStackTrace(forgotAwaitError, captureFunction);
+    hooks.add(forgotAwaitError);
+    let returned;
+    try {
+      returned = await func();
+      if (!isClosed) hooks.delete(forgotAwaitError);
+      return returned;
+    } catch (error) {
+      if (!isClosed) {
+        hooks.delete(forgotAwaitError);
+        throw error;
+      }
+    }
+  };
+
+  const close = () => {
+    if (isClosed) return;
+    isClosed = true;
+    activeAsyncHookTrackers.delete(asyncHookTracker);
+    if (hooks.size > 0) return hooks[Symbol.iterator]().next().value as Error;
+  };
+
+  const asyncHookTracker: AsyncHookTracker = { addHook, close };
+  activeAsyncHookTrackers.add(asyncHookTracker);
+  return asyncHookTracker;
+};

--- a/src/async-hooks.ts
+++ b/src/async-hooks.ts
@@ -36,14 +36,11 @@ export const createAsyncHookTracker = (): AsyncHookTracker => {
     removeFuncFromStackTrace(forgotAwaitError, captureFunction);
     hooks.add(forgotAwaitError);
     try {
-      const returned = await func();
-      if (!isClosed) hooks.delete(forgotAwaitError);
-      return returned;
+      return await func();
     } catch (error) {
-      if (!isClosed) {
-        hooks.delete(forgotAwaitError);
-        throw error;
-      }
+      if (!isClosed) throw error;
+    } finally {
+      if (!isClosed) hooks.delete(forgotAwaitError);
     }
   };
 

--- a/src/async-hooks.ts
+++ b/src/async-hooks.ts
@@ -35,9 +35,8 @@ export const createAsyncHookTracker = (): AsyncHookTracker => {
     );
     removeFuncFromStackTrace(forgotAwaitError, captureFunction);
     hooks.add(forgotAwaitError);
-    let returned;
     try {
-      returned = await func();
+      const returned = await func();
       if (!isClosed) hooks.delete(forgotAwaitError);
       return returned;
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import { cleanupClientRuntimeServer } from './module-server/client-runtime-serve
 import { Console } from 'console';
 import { createBuildStatusTracker } from './module-server/build-status-tracker';
 import { sourceMapErrorFromBrowser } from './source-map-error-from-browser';
+import type { AsyncHookTracker } from './async-hooks';
+import { createAsyncHookTracker } from './async-hooks';
 
 export { JSHandle, ElementHandle } from 'puppeteer';
 koloristOpts.enabled = true;
@@ -109,7 +111,7 @@ export const withBrowser: WithBrowser = (...args: any[]) => {
   const testPath = testFile ? relative(process.cwd(), testFile) : thisFile;
 
   return async () => {
-    const { state, cleanupServer, ...ctx } = await createTab({
+    const { state, cleanupServer, asyncHookTracker, ...ctx } = await createTab({
       testPath,
       options,
     });
@@ -125,7 +127,14 @@ export const withBrowser: WithBrowser = (...args: any[]) => {
 
     try {
       await testFn(ctx);
+      const forgotAwaitError = asyncHookTracker.close();
+      if (forgotAwaitError) throw forgotAwaitError;
     } catch (error) {
+      const forgotAwaitError = asyncHookTracker.close();
+      if (forgotAwaitError) {
+        await cleanup(false);
+        throw forgotAwaitError;
+      }
       const messageForBrowser: undefined | unknown[] =
         // This is how we attach the elements to the error from testing-library
         error?.messageForBrowser ||
@@ -220,10 +229,12 @@ const createTab = async ({
   PleasantestContext & {
     state: { isTestFinished: boolean };
     cleanupServer: () => Promise<void>;
+    asyncHookTracker: AsyncHookTracker;
   }
 > => {
   /** Used to provide helpful warnings if things execute after the test finishes (usually means they forgot to await) */
   const state = { isTestFinished: false };
+  const asyncHookTracker = createAsyncHookTracker();
   const browser = await connectToBrowser('chromium', headless);
   const browserContext = await browser.createIncognitoBrowserContext();
   const page = await browserContext.newPage();
@@ -310,90 +321,93 @@ const createTab = async ({
     });
   };
 
-  const runJS: PleasantestUtils['runJS'] = async (code, args) => {
-    // For some reason encodeURIComponent doesn't encode '
-    const encodedCode = encodeURIComponent(code).replace(/'/g, '%27');
-    const buildStatus = createBuildStatusTracker();
-    // This uses the testPath as the url so that if there are relative imports
-    // in the inline code, the relative imports are resolved relative to the test file
-    const url = `http://localhost:${port}/${testPath}?inline-code=${encodedCode}&build-id=${buildStatus.buildId}`;
-    const res = await safeEvaluate(
-      runJS,
-      new Function(
-        '...args',
-        `return import(${JSON.stringify(url)})
-        .then(async m => {
-          if (m.default) await m.default(...args)
-        })
-        .catch(e =>
-          e instanceof Error
+  const runJS: PleasantestUtils['runJS'] = (code, args) =>
+    asyncHookTracker.addHook(async () => {
+      // For some reason encodeURIComponent doesn't encode '
+      const encodedCode = encodeURIComponent(code).replace(/'/g, '%27');
+      const buildStatus = createBuildStatusTracker();
+      // This uses the testPath as the url so that if there are relative imports
+      // in the inline code, the relative imports are resolved relative to the test file
+      const url = `http://localhost:${port}/${testPath}?inline-code=${encodedCode}&build-id=${buildStatus.buildId}`;
+      // TODO
+      // asyncHookTracker.addHook(() => {});
+      const res = await page.evaluate(
+        new Function(
+          '...args',
+          `return import(${JSON.stringify(url)})
+            .then(async m => {
+              if (m.default) await m.default(...args)
+            })
+            .catch(e =>
+             e instanceof Error
+               ? { message: e.message, stack: e.stack }
+               : e)`,
+        ) as () => any,
+        ...(Array.isArray(args) ? (args as any) : []),
+      );
+
+      const errorsFromBuild = buildStatus.complete();
+      // It only throws the first one but that is probably OK
+      if (errorsFromBuild) throw errorsFromBuild[0];
+
+      await sourceMapErrorFromBrowser(res, requestCache, port, runJS);
+    }, runJS);
+  const injectHTML: PleasantestUtils['injectHTML'] = (html) =>
+    asyncHookTracker.addHook(
+      () =>
+        page.evaluate((html) => {
+          document.body.innerHTML = html;
+        }, html),
+      injectHTML,
+    );
+
+  const injectCSS: PleasantestUtils['injectCSS'] = (css) =>
+    asyncHookTracker.addHook(
+      () =>
+        page.evaluate((css) => {
+          const styleTag = document.createElement('style');
+          styleTag.innerHTML = css;
+          document.head.append(styleTag);
+        }, css),
+      injectCSS,
+    );
+
+  // TODO: continue migrating these to use the hook tracker
+
+  const loadCSS: PleasantestUtils['loadCSS'] = (cssPath) =>
+    asyncHookTracker.addHook(async () => {
+      const fullPath = isAbsolute(cssPath)
+        ? relative(process.cwd(), cssPath)
+        : join(dirname(testPath), cssPath);
+      await safeEvaluate(
+        loadCSS,
+        `import(${JSON.stringify(
+          `http://localhost:${port}/${fullPath}?import`,
+        )})`,
+      );
+    });
+
+  const loadJS: PleasantestUtils['loadJS'] = (jsPath) =>
+    asyncHookTracker.addHook(async () => {
+      const fullPath = jsPath.startsWith('.')
+        ? join(dirname(testPath), jsPath)
+        : jsPath;
+      const buildStatus = createBuildStatusTracker();
+      const url = `http://localhost:${port}/${fullPath}?build-id=${buildStatus.buildId}`;
+      const res = await safeEvaluate(
+        loadJS,
+        `import(${JSON.stringify(url)})
+          .catch(e => e instanceof Error
             ? { message: e.message, stack: e.stack }
             : e)`,
-      ) as () => any,
-      ...(Array.isArray(args) ? (args as any) : []),
-    );
+      );
 
-    const errorsFromBuild = buildStatus.complete();
-    // It only throws the first one but that is probably OK
-    if (errorsFromBuild) throw errorsFromBuild[0];
+      const errorsFromBuild = buildStatus.complete();
+      // It only throws the first one but that is probably OK
+      if (errorsFromBuild) throw errorsFromBuild[0];
 
-    await sourceMapErrorFromBrowser(res, requestCache, port, runJS);
-  };
-
-  const injectHTML: PleasantestUtils['injectHTML'] = async (html) => {
-    await safeEvaluate(
-      injectHTML,
-      (html) => {
-        document.body.innerHTML = html;
-      },
-      html,
-    );
-  };
-
-  const injectCSS: PleasantestUtils['injectCSS'] = async (css) => {
-    await safeEvaluate(
-      injectCSS,
-      (css) => {
-        const styleTag = document.createElement('style');
-        styleTag.innerHTML = css;
-        document.head.append(styleTag);
-      },
-      css,
-    );
-  };
-
-  const loadCSS: PleasantestUtils['loadCSS'] = async (cssPath) => {
-    const fullPath = isAbsolute(cssPath)
-      ? relative(process.cwd(), cssPath)
-      : join(dirname(testPath), cssPath);
-    await safeEvaluate(
-      loadCSS,
-      `import(${JSON.stringify(
-        `http://localhost:${port}/${fullPath}?import`,
-      )})`,
-    );
-  };
-
-  const loadJS: PleasantestUtils['loadJS'] = async (jsPath) => {
-    const fullPath = jsPath.startsWith('.')
-      ? join(dirname(testPath), jsPath)
-      : jsPath;
-    const buildStatus = createBuildStatusTracker();
-    const url = `http://localhost:${port}/${fullPath}?build-id=${buildStatus.buildId}`;
-    const res = await safeEvaluate(
-      loadJS,
-      `import(${JSON.stringify(url)})
-        .catch(e => e instanceof Error
-          ? { message: e.message, stack: e.stack }
-          : e)`,
-    );
-
-    const errorsFromBuild = buildStatus.complete();
-    // It only throws the first one but that is probably OK
-    if (errorsFromBuild) throw errorsFromBuild[0];
-
-    await sourceMapErrorFromBrowser(res, requestCache, port, loadJS);
-  };
+      await sourceMapErrorFromBrowser(res, requestCache, port, loadJS);
+    });
 
   const utils: PleasantestUtils = {
     runJS,
@@ -403,14 +417,14 @@ const createTab = async ({
     loadJS,
   };
 
-  const screen = getQueriesForElement(page, state);
+  const screen = getQueriesForElement(page, asyncHookTracker);
 
   // The | null is so you can pass directly the result of page.$() which returns null if not found
   const within: PleasantestContext['within'] = (
     element: puppeteer.ElementHandle | null,
   ) => {
     assertElementHandle(element, within);
-    return getQueriesForElement(page, state, element);
+    return getQueriesForElement(page, asyncHookTracker, element);
   };
 
   return {
@@ -418,8 +432,9 @@ const createTab = async ({
     utils,
     page,
     within,
-    user: await pleasantestUser(page, state),
+    user: await pleasantestUser(page, asyncHookTracker),
     state,
+    asyncHookTracker,
     cleanupServer: () => closeServer(),
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,12 +111,11 @@ export const withBrowser: WithBrowser = (...args: any[]) => {
   const testPath = testFile ? relative(process.cwd(), testFile) : thisFile;
 
   return async () => {
-    const { state, cleanupServer, asyncHookTracker, ...ctx } = await createTab({
+    const { cleanupServer, asyncHookTracker, ...ctx } = await createTab({
       testPath,
       options,
     });
     const cleanup = async (leaveOpen: boolean) => {
-      state.isTestFinished = true;
       if (!leaveOpen || options.headless) {
         await ctx.page.close();
       }
@@ -227,13 +226,10 @@ const createTab = async ({
   options: WithBrowserOpts;
 }): Promise<
   PleasantestContext & {
-    state: { isTestFinished: boolean };
     cleanupServer: () => Promise<void>;
     asyncHookTracker: AsyncHookTracker;
   }
 > => {
-  /** Used to provide helpful warnings if things execute after the test finishes (usually means they forgot to await) */
-  const state = { isTestFinished: false };
   const asyncHookTracker = createAsyncHookTracker();
   const browser = await connectToBrowser('chromium', headless);
   const browserContext = await browser.createIncognitoBrowserContext();
@@ -408,7 +404,6 @@ const createTab = async ({
     page,
     within,
     user: await pleasantestUser(page, asyncHookTracker),
-    state,
     asyncHookTracker,
     cleanupServer: () => closeServer(),
   };

--- a/tests/forgot-await.test.ts
+++ b/tests/forgot-await.test.ts
@@ -7,7 +7,7 @@ test('forgot await detection works even if other async stuff happens afterwards'
     await utils.injectHTML('<button>Asdf</button>');
     const buttonEl = await screen.getByRole('button');
     user.click(buttonEl);
-    await expect(buttonEl).toHaveTextContent(/asdf/i);
+    await screen.getByRole('button');
   })().catch((error) => error);
   expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
     "Error: Cannot interact with browser after test finishes. Did you forget to await?

--- a/tests/forgot-await.test.ts
+++ b/tests/forgot-await.test.ts
@@ -2,118 +2,158 @@
 import { withBrowser } from 'pleasantest';
 import { printErrorFrames } from './test-utils';
 
-test('forgot await in testing library query', (done) => {
-  withBrowser(async ({ screen }) => {
-    screen.getByText('hi').catch(async (error) => {
-      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
-        "Error: Cannot execute query getByText after test finishes. Did you forget to await?
-        -------------------------------------------------------
-        tests/forgot-await.test.ts
+test('forgot await detection works even if other async stuff happens afterwards', async () => {
+  const error = await withBrowser(async ({ screen, utils, user }) => {
+    await utils.injectHTML('<button>Asdf</button>');
+    const buttonEl = await screen.getByRole('button');
+    user.click(buttonEl);
+    await expect(buttonEl).toHaveTextContent(/asdf/i);
+  })().catch((error) => error);
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+    "Error: Cannot interact with browser after test finishes. Did you forget to await?
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
 
-            screen.getByText('hi').catch(async (error) => {
-                   ^
-        -------------------------------------------------------
-        dist/cjs/index.cjs"
-      `);
-      done();
-    });
-  })();
+        user.click(buttonEl);
+             ^
+    -------------------------------------------------------
+    dist/cjs/index.cjs
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+      const error = await withBrowser(async ({ screen, utils, user }) => {
+                    ^"
+    `);
 });
 
-test('forgot await in jest dom assertion', (done) => {
-  withBrowser(async ({ screen, utils }) => {
+test('forgot await in testing library query', async () => {
+  const error = await withBrowser(async ({ screen }) => {
+    screen.getByText('hi');
+  })().catch((error) => error);
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+    "Error: Cannot interact with browser after test finishes. Did you forget to await?
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+        screen.getByText('hi');
+               ^
+    -------------------------------------------------------
+    dist/cjs/index.cjs
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+      const error = await withBrowser(async ({ screen }) => {
+                    ^"
+    `);
+});
+
+test('forgot await in jest dom assertion', async () => {
+  const error = await withBrowser(async ({ screen, utils }) => {
     await utils.injectHTML('<button>Hi</button>');
     const button = await screen.getByText(/hi/i);
-    expect(button)
-      .toBeVisible()
-      .catch(async (error) => {
-        expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
-          "Error: Cannot execute assertion toBeVisible after test finishes. Did you forget to await?
-          -------------------------------------------------------
-          tests/forgot-await.test.ts
+    expect(button).toBeVisible();
+  })().catch((error) => error);
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+    "Error: Cannot interact with browser after test finishes. Did you forget to await?
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
 
-                .toBeVisible()
-                 ^
-          -------------------------------------------------------
-          dist/cjs/index.cjs"
-        `);
-        done();
-      });
-  })();
+        expect(button).toBeVisible();
+                       ^
+    -------------------------------------------------------
+    dist/cjs/index.cjs
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+      const error = await withBrowser(async ({ screen, utils }) => {
+                    ^"
+    `);
 });
 
-test('forgot await in utils.injectHTML', (done) => {
-  withBrowser(async ({ utils }) => {
-    utils.injectHTML('<button>Hi</button>').catch(async (error) => {
-      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
-        "Error: Cannot interact with browser using injectHTML after test finishes. Did you forget to await?
-        -------------------------------------------------------
-        tests/forgot-await.test.ts
+test('forgot await in utils.injectHTML', async () => {
+  const error = await withBrowser(async ({ utils }) => {
+    utils.injectHTML('<button>Hi</button>');
+  })().catch((error) => error);
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+    "Error: Cannot interact with browser after test finishes. Did you forget to await?
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
 
-            utils.injectHTML('<button>Hi</button>').catch(async (error) => {
-                  ^
-        -------------------------------------------------------
-        dist/cjs/index.cjs"
-      `);
-      done();
-    });
-  })();
+        utils.injectHTML('<button>Hi</button>');
+              ^
+    -------------------------------------------------------
+    dist/cjs/index.cjs
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+      const error = await withBrowser(async ({ utils }) => {
+                    ^"
+    `);
 });
 
-test('forgot await in utils.runJS', (done) => {
-  withBrowser(async ({ utils }) => {
-    utils.runJS('if (false) {}').catch(async (error) => {
-      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
-        "Error: Cannot interact with browser using runJS after test finishes. Did you forget to await?
-        -------------------------------------------------------
-        tests/forgot-await.test.ts
+test('forgot await in utils.runJS', async () => {
+  const error = await withBrowser(async ({ utils }) => {
+    utils.runJS('if (false) {}');
+  })().catch((error) => error);
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+    "Error: Cannot interact with browser after test finishes. Did you forget to await?
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
 
-            utils.runJS('if (false) {}').catch(async (error) => {
-                  ^
-        -------------------------------------------------------
-        dist/cjs/index.cjs"
-      `);
-      done();
-    });
-  })();
+        utils.runJS('if (false) {}');
+              ^
+    -------------------------------------------------------
+    dist/cjs/index.cjs
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+      const error = await withBrowser(async ({ utils }) => {
+                    ^"
+    `);
 });
 
-test('forgot await in user.click', (done) => {
-  withBrowser(async ({ user, utils, screen }) => {
+test('forgot await in user.click', async () => {
+  const error = await withBrowser(async ({ user, utils, screen }) => {
     await utils.injectHTML('<button>Hi</button>');
     const button = await screen.getByText('Hi');
-    user.click(button).catch(async (error) => {
-      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
-        "Error: Cannot interact with browser after test finishes. Did you forget to await?
-        -------------------------------------------------------
-        tests/forgot-await.test.ts
+    user.click(button);
+  })().catch((error) => error);
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+    "Error: Cannot interact with browser after test finishes. Did you forget to await?
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
 
-            user.click(button).catch(async (error) => {
-                 ^
-        -------------------------------------------------------
-        dist/cjs/index.cjs"
-      `);
-      done();
-    });
-  })();
+        user.click(button);
+             ^
+    -------------------------------------------------------
+    dist/cjs/index.cjs
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+      const error = await withBrowser(async ({ user, utils, screen }) => {
+                    ^"
+    `);
 });
 
-test('forgot await in user.type', (done) => {
-  withBrowser(async ({ user, utils, screen }) => {
+test('forgot await in user.type', async () => {
+  const error = await withBrowser(async ({ user, utils, screen }) => {
     await utils.injectHTML('<input />');
     const input = await screen.getByRole('textbox');
-    user.type(input, 'hello').catch(async (error) => {
-      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
-        "Error: Cannot interact with browser after test finishes. Did you forget to await?
-        -------------------------------------------------------
-        tests/forgot-await.test.ts
+    user.type(input, 'hello');
+  })().catch((error) => error);
+  expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+    "Error: Cannot interact with browser after test finishes. Did you forget to await?
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
 
-            user.type(input, 'hello').catch(async (error) => {
-                 ^
-        -------------------------------------------------------
-        dist/cjs/index.cjs"
-      `);
-      done();
-    });
-  })();
+        user.type(input, 'hello');
+             ^
+    -------------------------------------------------------
+    dist/cjs/index.cjs
+    -------------------------------------------------------
+    tests/forgot-await.test.ts
+
+      const error = await withBrowser(async ({ user, utils, screen }) => {
+                    ^"
+    `);
 });


### PR DESCRIPTION
When @spaceninja and I were working on some tests, we found a bug where the forgot-await detection didn't work:

```js
const buttonEl = await screen.getByRole("button", { name: /count/i });
await expect(buttonEl).toHaveTextContent(/count is: 0/i);
user.click(buttonEl); // Should trigger forgot-await error
await expect(buttonEl).toHaveTextContent(/count is: 3/i);
```

This is because the current implementation usually only works if the call with `await` missing is the last call inside withBrowser, because it depends on Jest's feature of listening for unhandled promise rejections.

This PR reimplements the forgot-await detection. Now it is centralized, and it works differently. It works by keeping track of all async calls that are _started_ inside `withBrowser`. When `withBrowser` finishes, it checks to see if any of the calls did not finish yet. If the developer remembered to use `await` on all the calls, then all the calls should have already finished, so nothing happens. If the developer forgot `await` on one or more of the calls, `withBrowser` can see that, and throw the error.

This does _not_ handle the case where the call that is missing `await` executes fast enough that it finishes before the rest of the things in `withBrowser`.

Review with whitespace changes turned off, otherwise the diff is a lot bigger than it needs to be