### PR TITLE
Fix regression with loadJS always throwing

### DIFF
--- a/.changeset/rich-dancers-invite.md
+++ b/.changeset/rich-dancers-invite.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Fix regression with loadJS always throwing

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,7 @@ const createTab = async ({
     const res = await safeEvaluate(
       loadJS,
       `import(${JSON.stringify(url)})
+        .then(mod => {})
         .catch(e => e instanceof Error
           ? { message: e.message, stack: e.stack }
           : e)`,

--- a/tests/utils/external-with-side-effect.ts
+++ b/tests/utils/external-with-side-effect.ts
@@ -1,0 +1,5 @@
+interface Window {
+  foo: string;
+}
+
+window.foo = 'hi';

--- a/tests/utils/loadJS.test.ts
+++ b/tests/utils/loadJS.test.ts
@@ -1,7 +1,14 @@
 import { withBrowser } from 'pleasantest';
 import { formatErrorWithCodeFrame, printErrorFrames } from '../test-utils';
 
-test.todo('loads from .ts file with transpiling');
+test(
+  'loads and executes .ts file with transpiling',
+  withBrowser(async ({ utils, page }) => {
+    expect(await page.evaluate(() => window.foo)).toBeUndefined();
+    await utils.loadJS('./external-with-side-effect.ts');
+    expect(await page.evaluate(() => window.foo)).toEqual('hi');
+  }),
+);
 
 test(
   'if the file throws an error the error is source mapped',


### PR DESCRIPTION
This is what happens when I don't write a test for the core functionality and use `test.todo` 😬 🙈 

Regression introduced in https://github.com/cloudfour/pleasantest/pull/199