### PR TITLE
Fix stack traces handling when calling user.* methods

### DIFF
--- a/.changeset/two-dingos-develop.md
+++ b/.changeset/two-dingos-develop.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Fix stack frames handling when calling user.\* methods

--- a/src/user.ts
+++ b/src/user.ts
@@ -41,6 +41,8 @@ const wrapWithForgotAwait = (
     const original = user[key];
     // eslint-disable-next-line @cloudfour/unicorn/consistent-function-scoping
     const wrapper = async (...args: any[]) =>
+      // The await is necessary so `wrapper` is in the stack trace,
+      // so captureStackTrace works correctly
       // eslint-disable-next-line no-return-await
       await asyncHookTracker.addHook<any>(
         () => (original as any)(...args),

--- a/src/user.ts
+++ b/src/user.ts
@@ -40,17 +40,12 @@ const wrapWithForgotAwait = (
   for (const key of Object.keys(user) as (keyof PleasantestUser)[]) {
     const original = user[key];
     // eslint-disable-next-line @cloudfour/unicorn/consistent-function-scoping
-    const wrapper = async (...args: any[]) => {
-      try {
-        return await asyncHookTracker.addHook<any>(
-          () => (original as any)(...args),
-          wrapper,
-        );
-      } catch (error) {
-        removeFuncFromStackTrace(error, wrapper);
-        throw error;
-      }
-    };
+    const wrapper = async (...args: any[]) =>
+      // eslint-disable-next-line no-return-await
+      await asyncHookTracker.addHook<any>(
+        () => (original as any)(...args),
+        wrapper,
+      );
 
     user[key] = wrapper;
   }

--- a/src/user.ts
+++ b/src/user.ts
@@ -40,8 +40,17 @@ const wrapWithForgotAwait = (
   for (const key of Object.keys(user) as (keyof PleasantestUser)[]) {
     const original = user[key];
     // eslint-disable-next-line @cloudfour/unicorn/consistent-function-scoping
-    const wrapper = (...args: any[]) =>
-      asyncHookTracker.addHook<any>(() => (original as any)(...args), wrapper);
+    const wrapper = async (...args: any[]) => {
+      try {
+        return await asyncHookTracker.addHook<any>(
+          () => (original as any)(...args),
+          wrapper,
+        );
+      } catch (error) {
+        removeFuncFromStackTrace(error, wrapper);
+        throw error;
+      }
+    };
 
     user[key] = wrapper;
   }

--- a/tests/user/general.test.ts
+++ b/tests/user/general.test.ts
@@ -1,0 +1,22 @@
+import { withBrowser } from 'pleasantest';
+import { printErrorFrames } from '../test-utils';
+
+test(
+  'Stack frames are correct',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML('<button style="visibility:hidden">Hi</button>');
+    const button = await screen.getByText(/hi/i);
+    const error = await user.click(button).catch((error) => error);
+    expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+      "Error: Cannot perform action on element that is not visible (it has visibility:hidden):
+      <button style=\\"visibility:hidden\\">Hi</button>
+      -------------------------------------------------------
+      tests/user/general.test.ts
+
+          const error = await user.click(button).catch((error) => error);
+                        ^
+      -------------------------------------------------------
+      dist/cjs/index.cjs"
+    `);
+  }),
+);


### PR DESCRIPTION
This fixes a bug that Gerardo and I found while implementing #248:
In #216, there is a regression in stack traces when an error is thrown from `user.*` methods.

For example, if you try to click an element that is invisible:

```js
await user.click(invisibleButton)
```

Then the correct/ideal behavior would be to show an error message with that line as the first line of the stack.
Since the regression in #216, the stack trace is missing entirely.

This PR adds it back, and adds a test to make sure that it stays there.