### PR TITLE
Fix regression in stack frames when DTL queries throw errors

### DIFF
--- a/.changeset/two-dingos-develop.md
+++ b/.changeset/two-dingos-develop.md
@@ -2,4 +2,4 @@
 'pleasantest': patch
 ---
 
-Fix stack frames handling when calling user.\* methods
+Fix regression in stack frames handling when calling `user.*` and `screen.*` methods.

--- a/src/pptr-testing-library.ts
+++ b/src/pptr-testing-library.ts
@@ -174,7 +174,7 @@ export const getQueriesForElement = (
           // @ts-expect-error messageForBrowser is a custom property that we add to Errors
           error.messageForBrowser = messageWithElementsRevived;
 
-          throw removeFuncFromStackTrace(error, query);
+          throw removeFuncFromStackTrace(error, queries[queryName]);
         }
 
         // If it returns a JSHandle<Array>, make it into an array of JSHandles so that using [0] for getAllBy* queries works
@@ -199,8 +199,13 @@ export const getQueriesForElement = (
 
       return [
         queryName,
-        (...args: any[]) =>
-          asyncHookTracker.addHook(() => query(...args), queries[queryName]),
+        async (...args: any[]): Promise<any> =>
+          // await is needed for correct stack trace
+          // eslint-disable-next-line no-return-await
+          await asyncHookTracker.addHook(
+            () => query(...args),
+            queries[queryName],
+          ),
       ];
     }),
   );

--- a/tests/testing-library-queries/variants-of-queries.test.ts
+++ b/tests/testing-library-queries/variants-of-queries.test.ts
@@ -1,5 +1,6 @@
 import type { ElementHandle } from 'pleasantest';
 import { withBrowser } from 'pleasantest';
+import { printErrorFrames } from '../test-utils';
 
 const singleElementMarkup = `
   <h1>Hello</h1>
@@ -66,6 +67,43 @@ test(
           `);
   }),
   10_000,
+);
+
+test(
+  'getBy',
+  withBrowser(async ({ screen, utils }) => {
+    await utils.injectHTML('<h1>Hi</h1>');
+    const error = await screen.getByRole('banner').catch((error) => error);
+    expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+      "Error: Unable to find an accessible element with the role \\"banner\\"
+
+      Here are the accessible roles:
+
+        document:
+
+        Name \\"\\":
+        <body>
+        <h1>Hi</h1>
+      </body>
+
+        --------------------------------------------------
+        heading:
+
+        Name \\"Hi\\":
+        <h1>Hi</h1>
+
+        --------------------------------------------------
+
+      Within: #document
+      -------------------------------------------------------
+      tests/testing-library-queries/variants-of-queries.test.ts
+
+          const error = await screen.getByRole('banner').catch((error) => error);
+                        ^
+      -------------------------------------------------------
+      dist/cjs/index.cjs"
+    `);
+  }),
 );
 
 test(


### PR DESCRIPTION
This goes hand in hand with #290. I realized that the `screen.*` methods have the same regression (I checked, the `expect().*` methods do not).

I fixed the regression in largely the same way, and added a snapshot test for the stack frames so if it breaks in the future we'll know