### PR TITLE
Allow passing a Page instead of an ElementHandle to getAccessibilityTree

### DIFF
--- a/.changeset/tall-spies-type.md
+++ b/.changeset/tall-spies-type.md
@@ -2,21 +2,6 @@
 'pleasantest': minor
 ---
 
-Add `screen.container` property
+Allow passing `page` instead of an `ElementHandle` to `getAccessibilityTree`.
 
-This is an easy way to get a reference to document.body:
-
-```js
-const body = await screen.container;
-```
-
-Anytime you access the container property, it will be an up-to-date reference to the latest `body`.
-
-This can also be used on queries bound to elements other than `screen`, to retrieve the container the queries were bound to:
-
-```js
-const elQueries = within(el);
-const container = await elQueries.container;
-```
-
-In this example, `container` and `el` are both `ElementHandle`s that point to the same element.
+If `page` is passed, the accessibility tree will be of the root `html` element.

--- a/.changeset/tall-spies-type.md
+++ b/.changeset/tall-spies-type.md
@@ -1,0 +1,22 @@
+---
+'pleasantest': minor
+---
+
+Add `screen.container` property
+
+This is an easy way to get a reference to document.body:
+
+```js
+const body = await screen.container;
+```
+
+Anytime you access the container property, it will be an up-to-date reference to the latest `body`.
+
+This can also be used on queries bound to elements other than `screen`, to retrieve the container the queries were bound to:
+
+```js
+const elQueries = within(el);
+const container = await elQueries.container;
+```
+
+In this example, `container` and `el` are both `ElementHandle`s that point to the same element.

--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ List of queries attached to screen object:
 - [`byTitle`](https://testing-library.com/docs/queries/bytitle): `getByTitle`, `queryByTitle`, `getAllByTitle`, `queryAllByTitle`, `findByTitle`, `findAllByTitle`
 - [`byTestId`](https://testing-library.com/docs/queries/bytestid): `getByTestId`, `queryByTestId`, `getAllByTestId`, `queryAllByTestId`, `findByTestId`, `findAllByTestId`
 
+There is also a `container` property which is the container that the queries are bound to, which in the case of `screen` always is `document.body`. It is a `Promise<ElementHandle>`, so you will have to `await` it. The `ElementHandle` points to `document.body`.
+
 ```js
 import { withBrowser } from 'pleasantest';
 
@@ -443,6 +445,8 @@ test(
 
 The `PleasantestContext` object exposes the `within` property, which is similar to [`screen`](#pleasantestcontextscreen), but instead of the queries being pre-bound to the document, they are pre-bound to whichever element you pass to it. [Here's Testing Library's docs on `within`](https://testing-library.com/docs/dom-testing-library/api-within). Like `screen`, it returns an object with all of the pre-bound Testing Library queries.
 
+The returned queries object also has a `container` property which can be used if you need a reference to the container that was originally passed to within(). `container` is a `Promise<ElementHandle>`, so you will have to `await` it.
+
 ```js
 import { withBrowser } from 'pleasantest';
 
@@ -450,14 +454,17 @@ test(
   'test name',
   withBrowser(async ({ within, screen }) => {
     //                 ^^^^^^
-    const containerElement = await screen.getByText(/hello/i);
-    const container = within(containerElement);
+    const helloElement = await screen.getByText(/hello/i);
+    const helloQueries = within(helloElement);
 
-    // Now `container` has queries bound to the container element
-    // You can use `container` in the same way as `screen`
+    // Now `helloQueries` has queries bound to the container element
+    // You can use `helloQueries` in the same way as `screen`
 
-    // Find elements matching /some element/i within the container element.
-    const someElement = await container.getByText(/some element/i);
+    // Find elements matching /some element/i within the `hello` element.
+    const someElement = await helloQueries.getByText(/some element/i);
+
+    const helloElement2 = await helloQueries.container;
+    // helloElement2 and helloElement are both ElementHandles pointing to the same element
   }),
 );
 ```
@@ -750,15 +757,15 @@ import { withBrowser, getAccessibilityTree } from 'pleasantest';
 
 test(
   'getAccessibilityTree example',
-  withBrowser(async ({ page }) => {
+  withBrowser(async ({ screen }) => {
     // ... Load your content here (see Loading Content)
 
-    const bodyElement = await page.evaluateHandle(() => document.body);
+    const body = await screen.container;
     // You could alternatively choose a more specific element for which to print the accessibility tree
 
     await expect(
       // Note the use of `await`; getAccessibilityTree returns a Promise
-      await getAccessibilityTree(bodyElement),
+      await getAccessibilityTree(body),
     ).toMatchInlineSnapshot();
   }),
 );

--- a/README.md
+++ b/README.md
@@ -443,6 +443,22 @@ test(
 
 The `PleasantestContext` object exposes the `within` property, which is similar to [`screen`](#pleasantestcontextscreen), but instead of the queries being pre-bound to the document, they are pre-bound to whichever element you pass to it. [Here's Testing Library's docs on `within`](https://testing-library.com/docs/dom-testing-library/api-within). Like `screen`, it returns an object with all of the pre-bound Testing Library queries.
 
+```js
+import { withBrowser } from 'pleasantest';
+test(
+  'test name',
+  withBrowser(async ({ within, screen }) => {
+    //                 ^^^^^^
+    const containerElement = await screen.getByText(/hello/i);
+    const container = within(containerElement);
+    // Now `container` has queries bound to the container element
+    // You can use `container` in the same way as `screen`
+    // Find elements matching /some element/i within the container element.
+    const someElement = await container.getByText(/some element/i);
+  }),
+);
+```
+
 #### `PleasantestContext.page`
 
 The `PleasantestContext` object exposes the `page` property, which is an instance of Puppeteer's [`Page` class](https://pptr.dev/#?product=Puppeteer&version=v13.0.0&show=api-class-page). This will most often be used for navigation ([`page.goto`](https://pptr.dev/#?product=Puppeteer&version=v13.0.0&show=api-pagegotourl-options)), but you can do anything with it that you can do with puppeteer.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Pleasantest is a library that allows you test web applications using real browse
   - [User API: `PleasantestUser`](#user-api-pleasantestuser)
   - [Utilities API: `PleasantestUtils`](#utilities-api-pleasantestutils)
   - [`jest-dom` Matchers](#jest-dom-matchers)
-  - [`getAccessibilityTree`](#getaccessibilitytreeelement-options-accessibilitytreeoptions--promiseaccessibilitytreesnapshot)
+  - [`getAccessibilityTree`](#getaccessibilitytreeelement-elementhandle--page-options-accessibilitytreeoptions--promiseaccessibilitytreesnapshot)
 - [Puppeteer Tips](#puppeteer-tips)
 - [Comparisons with other testing tools](#comparisons-with-other-testing-tools)
 - [Limitations](#limitationsarchitectural-decisions)
@@ -223,7 +223,7 @@ test(
 );
 ```
 
-Another option is to use the [`getAccessibilityTree`](#getaccessibilitytreeelement-options-accessibilitytreeoptions--promiseaccessibilitytreesnapshot) function to create snapshots of the expected accessibility tree.
+Another option is to use the [`getAccessibilityTree`](#getaccessibilitytreeelement-elementhandle--page-options-accessibilitytreeoptions--promiseaccessibilitytreesnapshot) function to create snapshots of the expected accessibility tree.
 
 ### Performing Actions
 

--- a/README.md
+++ b/README.md
@@ -426,8 +426,6 @@ List of queries attached to screen object:
 - [`byTitle`](https://testing-library.com/docs/queries/bytitle): `getByTitle`, `queryByTitle`, `getAllByTitle`, `queryAllByTitle`, `findByTitle`, `findAllByTitle`
 - [`byTestId`](https://testing-library.com/docs/queries/bytestid): `getByTestId`, `queryByTestId`, `getAllByTestId`, `queryAllByTestId`, `findByTestId`, `findAllByTestId`
 
-There is also a `container` property which is the container that the queries are bound to, which in the case of `screen` always is `document.body`. It is a `Promise<ElementHandle>`, so you will have to `await` it. The `ElementHandle` points to `document.body`.
-
 ```js
 import { withBrowser } from 'pleasantest';
 
@@ -444,30 +442,6 @@ test(
 #### `PleasantestContext.within(element: ElementHandle)`
 
 The `PleasantestContext` object exposes the `within` property, which is similar to [`screen`](#pleasantestcontextscreen), but instead of the queries being pre-bound to the document, they are pre-bound to whichever element you pass to it. [Here's Testing Library's docs on `within`](https://testing-library.com/docs/dom-testing-library/api-within). Like `screen`, it returns an object with all of the pre-bound Testing Library queries.
-
-The returned queries object also has a `container` property which can be used if you need a reference to the container that was originally passed to within(). `container` is a `Promise<ElementHandle>`, so you will have to `await` it.
-
-```js
-import { withBrowser } from 'pleasantest';
-
-test(
-  'test name',
-  withBrowser(async ({ within, screen }) => {
-    //                 ^^^^^^
-    const helloElement = await screen.getByText(/hello/i);
-    const helloQueries = within(helloElement);
-
-    // Now `helloQueries` has queries bound to the container element
-    // You can use `helloQueries` in the same way as `screen`
-
-    // Find elements matching /some element/i within the `hello` element.
-    const someElement = await helloQueries.getByText(/some element/i);
-
-    const helloElement2 = await helloQueries.container;
-    // helloElement2 and helloElement are both ElementHandles pointing to the same element
-  }),
-);
-```
 
 #### `PleasantestContext.page`
 
@@ -744,7 +718,7 @@ test(
 );
 ```
 
-### `getAccessibilityTree(element, options?: AccessibilityTreeOptions) => Promise<AccessibilityTreeSnapshot>`
+### `getAccessibilityTree(element: ElementHandle | Page, options?: AccessibilityTreeOptions) => Promise<AccessibilityTreeSnapshot>`
 
 The `getAccessibilityTree` function is a top-level import from `pleasantest`. It is intended to be used with [Jest Snapshots](https://jestjs.io/docs/snapshot-testing#snapshot-testing-with-jest) to ensure that any changes to the accessibility tree of your component or application are intended and correct.
 
@@ -757,15 +731,13 @@ import { withBrowser, getAccessibilityTree } from 'pleasantest';
 
 test(
   'getAccessibilityTree example',
-  withBrowser(async ({ screen }) => {
+  withBrowser(async ({ page }) => {
     // ... Load your content here (see Loading Content)
-
-    const body = await screen.container;
-    // You could alternatively choose a more specific element for which to print the accessibility tree
 
     await expect(
       // Note the use of `await`; getAccessibilityTree returns a Promise
-      await getAccessibilityTree(body),
+      // Also, you could pass a specific element instead of the page
+      await getAccessibilityTree(page),
     ).toMatchInlineSnapshot();
   }),
 );
@@ -782,6 +754,8 @@ list
   listitem
     text "something else"
 ```
+
+The first parameter must be either an `ElementHandle` or the `Page` object. If an `ElementHandle` is passed, the accessibility tree will contain only descendants of that element. If the `Page` object is passed, the accessibility tree will be of the entire document.
 
 The second parameter (optional) is `AccessibilityTreeOptions`, and it allows you to configure what is shown in the output.
 

--- a/README.md
+++ b/README.md
@@ -445,14 +445,17 @@ The `PleasantestContext` object exposes the `within` property, which is similar 
 
 ```js
 import { withBrowser } from 'pleasantest';
+
 test(
   'test name',
   withBrowser(async ({ within, screen }) => {
     //                 ^^^^^^
     const containerElement = await screen.getByText(/hello/i);
     const container = within(containerElement);
+
     // Now `container` has queries bound to the container element
     // You can use `container` in the same way as `screen`
+
     // Find elements matching /some element/i within the container element.
     const someElement = await container.getByText(/some element/i);
   }),

--- a/src/pptr-testing-library.ts
+++ b/src/pptr-testing-library.ts
@@ -41,8 +41,6 @@ type ChangeDTLFn<DTLFn extends ValueOf<typeof queries>> = DTLFn extends (
 
 export type BoundQueries = {
   [K in keyof typeof queries]: ChangeDTLFn<typeof queries[K]>;
-} & {
-  container: Promise<ElementHandle>;
 };
 
 const queryNames = [
@@ -214,22 +212,6 @@ export const getQueriesForElement = (
           ),
       ];
     }),
-  );
-
-  Object.defineProperty(
-    queries,
-    'container',
-    element
-      ? // If a root element was passed in (from calling within())
-        // Then we can always return that value directly
-        // when they use screen.container
-        { value: Promise.resolve(element) }
-      : // If they did not pass a root element, then the queries are run from document.body.
-        // document.body is not static, it can change if a different page is loaded
-        // or even if you replace the body element in the page.
-        // So we must return a getter for screen.container
-        // so that it always reflects the most up to date document.body
-        { get: () => page.evaluateHandle(() => document.body) },
   );
 
   return queries;

--- a/src/pptr-testing-library.ts
+++ b/src/pptr-testing-library.ts
@@ -41,6 +41,8 @@ type ChangeDTLFn<DTLFn extends ValueOf<typeof queries>> = DTLFn extends (
 
 export type BoundQueries = {
   [K in keyof typeof queries]: ChangeDTLFn<typeof queries[K]>;
+} & {
+  container: Promise<ElementHandle>;
 };
 
 const queryNames = [
@@ -212,6 +214,22 @@ export const getQueriesForElement = (
           ),
       ];
     }),
+  );
+
+  Object.defineProperty(
+    queries,
+    'container',
+    element
+      ? // If a root element was passed in (from calling within())
+        // Then we can always return that value directly
+        // when they use screen.container
+        { value: Promise.resolve(element) }
+      : // If they did not pass a root element, then the queries are run from document.body.
+        // document.body is not static, it can change if a different page is loaded
+        // or even if you replace the body element in the page.
+        // So we must return a getter for screen.container
+        // so that it always reflects the most up to date document.body
+        { get: () => page.evaluateHandle(() => document.body) },
   );
 
   return queries;

--- a/tests/accessibility/getAccessibilityTree.test.ts
+++ b/tests/accessibility/getAccessibilityTree.test.ts
@@ -1,9 +1,28 @@
+import type { ElementHandle } from 'pleasantest';
 import { getAccessibilityTree, withBrowser } from 'pleasantest';
 
 test(
+  'allows passing page instead of element',
+  withBrowser(async ({ utils, page }) => {
+    await utils.injectHTML(`<ul></ul>`);
+    await page.evaluate(() => (document.title = 'example title'));
+    const htmlElement = await page.evaluateHandle<ElementHandle>(
+      () => document.documentElement,
+    );
+    expect(String(await getAccessibilityTree(htmlElement))).toEqual(
+      String(await getAccessibilityTree(page)),
+    );
+    // TODO: document's name should be from document.title (breaking change)
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        list
+    `);
+  }),
+);
+
+test(
   'basic use cases',
-  withBrowser(async ({ utils, screen }) => {
-    const body = await screen.container;
+  withBrowser(async ({ utils, page }) => {
     await utils.injectHTML(`
       <main>
         <button>
@@ -14,12 +33,13 @@ test(
         <div role="button" tabindex="-1">foo &gt bar</div>
       </main>
     `);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      main
-        button "Add to cart"
-        heading "hiiii"
-          text "hiiii"
-        button "foo > bar"
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        main
+          button "Add to cart"
+          heading "hiiii"
+            text "hiiii"
+          button "foo > bar"
     `);
     await utils.injectHTML(`
       <ul>
@@ -27,38 +47,31 @@ test(
         <li>something else</li>
       </ul>
     `);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      list
-        listitem
-          text "something"
-        listitem
-          text "something else"
-    `);
-    expect(await getAccessibilityTree(body, { includeText: true }))
-      .toMatchInlineSnapshot(`
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
         list
           listitem
             text "something"
           listitem
             text "something else"
-      `);
+    `);
+    expect(await getAccessibilityTree(page, { includeText: true }))
+      .toMatchInlineSnapshot(`
+      document
+        list
+          listitem
+            text "something"
+          listitem
+            text "something else"
+    `);
     await utils.injectHTML(`
       <button aria-describedby="click-me-description">click me</button>
       <button aria-describedby="click-me-description"><div>click me</div></button>
       <button aria-describedby="click-me-description"><h1>click me</h1></button>
       <div id="click-me-description">extended description</div>
     `);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      button "click me"
-        ↳ description: "extended description"
-      button "click me"
-        ↳ description: "extended description"
-      button "click me"
-        ↳ description: "extended description"
-      text "extended description"
-    `);
-    expect(await getAccessibilityTree(body, { includeText: true }))
-      .toMatchInlineSnapshot(`
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
         button "click me"
           ↳ description: "extended description"
         button "click me"
@@ -66,14 +79,26 @@ test(
         button "click me"
           ↳ description: "extended description"
         text "extended description"
-      `);
-
-    expect(await getAccessibilityTree(body, { includeDescriptions: false }))
+    `);
+    expect(await getAccessibilityTree(page, { includeText: true }))
       .toMatchInlineSnapshot(`
-      button "click me"
-      button "click me"
-      button "click me"
-      text "extended description"
+      document
+        button "click me"
+          ↳ description: "extended description"
+        button "click me"
+          ↳ description: "extended description"
+        button "click me"
+          ↳ description: "extended description"
+        text "extended description"
+    `);
+
+    expect(await getAccessibilityTree(page, { includeDescriptions: false }))
+      .toMatchInlineSnapshot(`
+      document
+        button "click me"
+        button "click me"
+        button "click me"
+        text "extended description"
     `);
 
     await utils.injectHTML(`
@@ -86,19 +111,20 @@ test(
       <input type="text" id="input"/>
     `);
 
-    expect(await getAccessibilityTree(body, { includeText: true }))
+    expect(await getAccessibilityTree(page, { includeText: true }))
       .toMatchInlineSnapshot(`
+      document
         text "Label Text"
         textbox "Label Text"
         text "Label Text"
         textbox "Label Text"
-      `);
+    `);
   }),
 );
 
 test(
   'hidden elements are excluded',
-  withBrowser(async ({ utils, screen }) => {
+  withBrowser(async ({ utils, page }) => {
     // https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
     await utils.injectHTML(`
       <button>A</button>
@@ -124,33 +150,34 @@ test(
         <button style="visibility: visible">L</button>
       </div>
     `);
-    const body = await screen.container;
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      button "A"
-      button "E"
-      button "G"
-      button "H"
-      button "L"
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        button "A"
+        button "E"
+        button "G"
+        button "H"
+        button "L"
     `);
   }),
 );
 
 test(
   'role="presentation"',
-  withBrowser(async ({ utils, screen }) => {
-    const body = await screen.container;
+  withBrowser(async ({ utils, page }) => {
     await utils.injectHTML(`<h1 role="presentation">Sample Content</h1>`);
     // Role="presentation" and role="none" are equivalent
     // They make it as if the outer element wasn't there.
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(
-      `text "Sample Content"`,
-    );
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        text "Sample Content"
+    `);
     await utils.injectHTML(`<h1 role="none">Sample Content</h1>`);
     // Role="presentation" and role="none" are equivalent
     // They make it as if the outer element wasn't there.
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(
-      `text "Sample Content"`,
-    );
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        text "Sample Content"
+    `);
 
     // The li (role=listitem) children are required owned elements of the ul (role=list)
     // When the list is set to role=presentation,
@@ -164,11 +191,12 @@ test(
         <li role="heading">Hi</li>
       </ul>
     `);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "Sample Content"
-      text "More Sample Content"
-      heading "Hi"
-        text "Hi"
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        text "Sample Content"
+        text "More Sample Content"
+        heading "Hi"
+          text "Hi"
     `);
     // Now the third list item has an explicit role which is the same as its implicit role.
     // When the list gets role="presentation",
@@ -181,11 +209,12 @@ test(
         <li role="listitem">Hi</li>
       </ul>
     `);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "Sample Content"
-      text "More Sample Content"
-      listitem
-        text "Hi"
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        text "Sample Content"
+        text "More Sample Content"
+        listitem
+          text "Hi"
     `);
     // The required owned elements search should pass through elements without roles
     await utils.injectHTML(`
@@ -197,11 +226,12 @@ test(
         <li role="heading">Hi</li>
       </ul>
     `);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "Sample Content"
-      text "More Sample Content"
-      heading "Hi"
-        text "Hi"
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        text "Sample Content"
+        text "More Sample Content"
+        heading "Hi"
+          text "Hi"
     `);
     // The required owned elements search should _not_ pass through elements with roles
     await utils.injectHTML(`
@@ -213,34 +243,35 @@ test(
         <li role="heading">Hi</li>
       </ul>
     `);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      heading "Sample Content"
-        listitem
-          text "Sample Content"
-      text "More Sample Content"
-      heading "Hi"
-        text "Hi"
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        heading "Sample Content"
+          listitem
+            text "Sample Content"
+        text "More Sample Content"
+        heading "Hi"
+          text "Hi"
     `);
   }),
 );
 
 test(
   'labels which element is focused',
-  withBrowser(async ({ utils, user, screen }) => {
+  withBrowser(async ({ utils, user, screen, page }) => {
     await utils.injectHTML(`
       <button>Click me!</button>
     `);
 
-    const body = await screen.container;
-
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(
-      `button "Click me!"`,
-    );
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        button "Click me!"
+    `);
 
     await user.click(await screen.getByRole('button'));
 
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(
-      `button "Click me!" (focused)`,
-    );
+    expect(await getAccessibilityTree(page)).toMatchInlineSnapshot(`
+      document
+        button "Click me!" (focused)
+    `);
   }),
 );

--- a/tests/accessibility/getAccessibilityTree.test.ts
+++ b/tests/accessibility/getAccessibilityTree.test.ts
@@ -2,8 +2,8 @@ import type { ElementHandle } from 'pleasantest';
 import { getAccessibilityTree, withBrowser } from 'pleasantest';
 
 test(
-  'allows passing page instead of element',
-  withBrowser(async ({ utils, page }) => {
+  'allows passing Page or ElementHandle',
+  withBrowser(async ({ utils, page, screen }) => {
     await utils.injectHTML(`<ul></ul>`);
     await page.evaluate(() => (document.title = 'example title'));
     const htmlElement = await page.evaluateHandle<ElementHandle>(
@@ -17,6 +17,11 @@ test(
       document
         list
     `);
+
+    const list = await screen.getByRole('list');
+
+    // Allows passing a more specific element to get a subtree
+    expect(await getAccessibilityTree(list)).toMatchInlineSnapshot(`list`);
   }),
 );
 

--- a/tests/accessibility/getAccessibilityTree.test.ts
+++ b/tests/accessibility/getAccessibilityTree.test.ts
@@ -1,9 +1,9 @@
-import type { ElementHandle } from 'pleasantest';
 import { getAccessibilityTree, withBrowser } from 'pleasantest';
 
 test(
   'basic use cases',
-  withBrowser(async ({ utils, page }) => {
+  withBrowser(async ({ utils, screen }) => {
+    const body = await screen.container;
     await utils.injectHTML(`
       <main>
         <button>
@@ -14,7 +14,6 @@ test(
         <div role="button" tabindex="-1">foo &gt bar</div>
       </main>
     `);
-    const body = await page.evaluateHandle<ElementHandle>(() => document.body);
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
       main
         button "Add to cart"
@@ -99,7 +98,7 @@ test(
 
 test(
   'hidden elements are excluded',
-  withBrowser(async ({ utils, page }) => {
+  withBrowser(async ({ utils, screen }) => {
     // https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
     await utils.injectHTML(`
       <button>A</button>
@@ -125,7 +124,7 @@ test(
         <button style="visibility: visible">L</button>
       </div>
     `);
-    const body = await page.evaluateHandle<ElementHandle>(() => document.body);
+    const body = await screen.container;
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
       button "A"
       button "E"
@@ -138,8 +137,8 @@ test(
 
 test(
   'role="presentation"',
-  withBrowser(async ({ utils, page }) => {
-    const body = (await page.$('body'))!;
+  withBrowser(async ({ utils, screen }) => {
+    const body = await screen.container;
     await utils.injectHTML(`<h1 role="presentation">Sample Content</h1>`);
     // Role="presentation" and role="none" are equivalent
     // They make it as if the outer element wasn't there.
@@ -227,12 +226,12 @@ test(
 
 test(
   'labels which element is focused',
-  withBrowser(async ({ utils, page, user, screen }) => {
+  withBrowser(async ({ utils, user, screen }) => {
     await utils.injectHTML(`
       <button>Click me!</button>
     `);
 
-    const body = await page.evaluateHandle<ElementHandle>(() => document.body);
+    const body = await screen.container;
 
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(
       `button "Click me!"`,

--- a/tests/testing-library-queries/within.test.ts
+++ b/tests/testing-library-queries/within.test.ts
@@ -1,3 +1,4 @@
+import type { ElementHandle } from 'pleasantest';
 import { withBrowser } from 'pleasantest';
 
 test(
@@ -32,13 +33,33 @@ test(
       name: /checkout/i,
     });
 
-    const checkout = within(
-      (await checkoutHeading.evaluateHandle(
+    const checkoutContainer =
+      await checkoutHeading.evaluateHandle<ElementHandle>(
         (heading) => heading.parentElement,
-      )) as any,
-    );
+      );
+
+    const checkoutQueries = within(checkoutContainer);
 
     // This should pass now because there is only one button within the checkout section
-    await checkout.getByRole('button');
+    await checkoutQueries.getByRole('button');
+
+    // The .container property returns a promise resolving to the container element
+    await utils.runJS(
+      `export default (originalContainer, containerReference) => {
+        if (originalContainer !== containerReference)
+          throw new Error('.container property did not return correct reference')
+      }`,
+      [checkoutContainer, await checkoutQueries.container],
+    );
+
+    // Also screen.container should exist as well and should point to document.body
+    // since screen === within(document.body)
+    await utils.runJS(
+      `export default (container) => {
+        if (document.body !== container)
+          throw new Error('.container property did not return correct reference')
+      }`,
+      [await screen.container],
+    );
   }),
 );

--- a/tests/testing-library-queries/within.test.ts
+++ b/tests/testing-library-queries/within.test.ts
@@ -42,24 +42,5 @@ test(
 
     // This should pass now because there is only one button within the checkout section
     await checkoutQueries.getByRole('button');
-
-    // The .container property returns a promise resolving to the container element
-    await utils.runJS(
-      `export default (originalContainer, containerReference) => {
-        if (originalContainer !== containerReference)
-          throw new Error('.container property did not return correct reference')
-      }`,
-      [checkoutContainer, await checkoutQueries.container],
-    );
-
-    // Also screen.container should exist as well and should point to document.body
-    // since screen === within(document.body)
-    await utils.runJS(
-      `export default (container) => {
-        if (document.body !== container)
-          throw new Error('.container property did not return correct reference')
-      }`,
-      [await screen.container],
-    );
   }),
 );


### PR DESCRIPTION
## Overview

After using `getAccessibilityTree` a bit I realized that it is very common to want to do `getAccessibilityTree` on the whole document, so I made a shortcut to get a reference to the body element:

```js
const body = await screen.container
```

This is equivalent to:

```ts
const body = await page.evaluateHandle<ElementHandle>(() => document.body)
```

Also, it can be used to get a reference to the container element used after calling `within(el)` to get queries scoped to a specific element:

```ts
const elQueries = within(el)
const container = await elQueries.container
```

In this example, `container` and `el` are both `ElementHandle`s that point to the same element.

## Alternate solutions

- Other names for `.container`
  - `root`
  - `el`
  - `element`
- Make `getAccessibilityTree` default to the document if no element is passed
  ```js
  expect(await getAccessibilityTree(/* implied body */)).toMatchInlineSnapshot()
  ```
- Add a parameter that is passed to the `withBrowser` callback
  ```js
  withBrowser(async ({ getBody }) => {
    const body = await getBody()
  })
  ```

I don't know which of these solutions would be best (it is also possible to implement multiple of them). Let me know if y'all have thoughts on which would be best, it would be pretty easy to implement any of them.