### PR TITLE
Ignore HTML comments in `getAccessibilityTree` output

### DIFF
--- a/.changeset/heavy-wombats-vanish.md
+++ b/.changeset/heavy-wombats-vanish.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Ignore HTML comments in `getAccessibilityTree` output (potentially breaking bugfix)

--- a/src/accessibility/browser.ts
+++ b/src/accessibility/browser.ts
@@ -122,7 +122,7 @@ export const getAccessibilityTree = (
     let printedChild;
     if (node instanceof Element) {
       printedChild = getAccessibilityTree(node, opts, requiredOwnedElements);
-    } else if (includeText) {
+    } else if (includeText && !(node instanceof Comment)) {
       const trimmedText = node.nodeValue?.trim();
       if (!trimmedText) continue;
 

--- a/tests/accessibility/getAccessibilityTree.test.ts
+++ b/tests/accessibility/getAccessibilityTree.test.ts
@@ -34,6 +34,7 @@ test(
           <span aria-hidden="true">+</span>
           <span>Add to cart</span>
         </button>
+        <!-- This comment shouldn't show up -->
         <h1>hiiii</h1>
         <div role="button" tabindex="-1">foo &gt bar</div>
       </main>


### PR DESCRIPTION
Closes #411 