### PR TITLE
Add toPassAxeTests feature

### DIFF
--- a/.changeset/early-pigs-beg.md
+++ b/.changeset/early-pigs-beg.md
@@ -1,0 +1,22 @@
+---
+'pleasantest': minor
+---
+
+New assertion: `expect(page).toPassAxeTests()`
+
+This assertion is based on the [`jest-puppeteer-axe`](https://github.com/WordPress/gutenberg/tree/3b2eccc289cfc90bd99252b12fc4c6e470ce4c04/packages/jest-puppeteer-axe) package. (That package already works with Pleasantest, our new feature just formats error messages a little differently)
+
+It allows you to pass a page to be checked with the [axe accessibility linter](https://github.com/dequelabs/axe-core).
+
+```js
+test(
+  'Axe tests',
+  withBrowser(async ({ utils, page }) => {
+    await utils.injectHTML(`
+      <h1>Some html</h1>
+    `);
+
+    await expect(page).toPassAxeTests();
+  }),
+);
+```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Pleasantest is a library that allows you test web applications using real browse
   - [Utilities API: `PleasantestUtils`](#utilities-api-pleasantestutils)
   - [`jest-dom` Matchers](#jest-dom-matchers)
   - [`getAccessibilityTree`](#getaccessibilitytreeelement-elementhandle--page-options-accessibilitytreeoptions--promiseaccessibilitytreesnapshot)
-  - [`toPassAxeTests`](#topassaxetests--options-topassaxetestsopts)
+  - [`toPassAxeTests`](#expectpagetopassaxetestsopts-topassaxetestsopts)
 - [Puppeteer Tips](#puppeteer-tips)
 - [Comparisons with other testing tools](#comparisons-with-other-testing-tools)
 - [Limitations](#limitationsarchitectural-decisions)

--- a/README.md
+++ b/README.md
@@ -835,6 +835,8 @@ The returned `Promise` wraps an `AccessibilityTreeSnapshot`, which can be passed
 
 This assertion, based on [`jest-puppeteer-axe`](https://github.com/WordPress/gutenberg/tree/3b2eccc289cfc90bd99252b12fc4c6e470ce4c04/packages/jest-puppeteer-axe), allows you to check a page using the [axe accessibility linter](https://github.com/dequelabs/axe-core).
 
+To use this assertion, you **must install `@axe-core/puppeteer` and `axe-core`**. They are optional peer dependencies for Pleasantest, but are needed for the `toPassAxeTests` assertion.
+
 ```js
 test(
   'Axe tests',

--- a/README.md
+++ b/README.md
@@ -854,9 +854,9 @@ test(
 
 - `include`: `string | string[]`: CSS selector(s) to add to the list of elements to include in analysis.
 - `exclude`: `string | string[]`: CSS selector(s) to add to the list of elements to exclude from analysis.
-- `disabledRules`: `string | string[]`: The list of Axe rules to skip from verification.
-- `options`: `axe.RunOptions`: A flexible way to [configure how Axe run operates](https://github.com/dequelabs/axe-core/blob/HEAD/doc/API.md#options-parameter).
-- `config`: `axe.Spec`: [Axe configuration object](https://github.com/dequelabs/axe-core/blob/HEAD/doc/API.md#api-name-axeconfigure).
+- `disabledRules`: `string | string[]`: The list of [Axe rules](https://github.com/dequelabs/axe-core/tree/v4.4.2/lib/rules) to skip from verification.
+- `options`: [`axe.RunOptions`](https://github.com/dequelabs/axe-core/blob/v4.4.2/axe.d.ts#L89): A flexible way to [configure how Axe run operates](https://github.com/dequelabs/axe-core/blob/HEAD/doc/API.md#options-parameter).
+- `config`: [`axe.Spec`](https://github.com/dequelabs/axe-core/blob/v4.4.2/axe.d.ts#L195): [Axe configuration object](https://github.com/dequelabs/axe-core/blob/HEAD/doc/API.md#api-name-axeconfigure).
 
 ## Puppeteer Tips
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Pleasantest is a library that allows you test web applications using real browse
   - [Utilities API: `PleasantestUtils`](#utilities-api-pleasantestutils)
   - [`jest-dom` Matchers](#jest-dom-matchers)
   - [`getAccessibilityTree`](#getaccessibilitytreeelement-elementhandle--page-options-accessibilitytreeoptions--promiseaccessibilitytreesnapshot)
+  - [`toPassAxeTests`](#topassaxetests--options-topassaxetestsopts)
 - [Puppeteer Tips](#puppeteer-tips)
 - [Comparisons with other testing tools](#comparisons-with-other-testing-tools)
 - [Limitations](#limitationsarchitectural-decisions)
@@ -829,6 +830,31 @@ The second parameter (optional) is `AccessibilityTreeOptions`, and it allows you
 Disabling these options can be used to reduce the output or to exclude text that is intended to frequently change.
 
 The returned `Promise` wraps an `AccessibilityTreeSnapshot`, which can be passed directly as the `expect` first parameter in `expect(___).toMatchInlineSnapshot()`. The returned object can also be converted to a string using `String(accessibilityTreeSnapshot)`.
+
+### `expect(page).toPassAxeTests(opts?: ToPassAxeTestsOpts)`
+
+This assertion, based on [`jest-puppeteer-axe`](https://github.com/WordPress/gutenberg/tree/3b2eccc289cfc90bd99252b12fc4c6e470ce4c04/packages/jest-puppeteer-axe), allows you to check a page using the [axe accessibility linter](https://github.com/dequelabs/axe-core).
+
+```js
+test(
+  'Axe tests',
+  withBrowser(async ({ utils, page }) => {
+    await utils.injectHTML(`
+      <h1>Some html</h1>
+    `);
+
+    await expect(page).toPassAxeTests();
+  }),
+);
+```
+
+`ToPassAxeTestsOpts` (all properties are optional):
+
+- `include`: `string | string[]`: CSS selector(s) to add to the list of elements to include in analysis.
+- `exclude`: `string | string[]`: CSS selector(s) to add to the list of elements to exclude from analysis.
+- `disabledRules`: `string | string[]`: The list of Axe rules to skip from verification.
+- `options`: `axe.RunOptions`: A flexible way to [configure how Axe run operates](https://github.com/dequelabs/axe-core/blob/HEAD/doc/API.md#options-parameter).
+- `config`: `axe.Spec`: [Axe configuration object](https://github.com/dequelabs/axe-core/blob/HEAD/doc/API.md#api-name-axeconfigure).
 
 ## Puppeteer Tips
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,18 @@
       },
       "engines": {
         "node": "^12.2 || 14 || 16 || 17 || 18"
+      },
+      "peerDependencies": {
+        "@axe-core/puppeteer": "^4.4.2",
+        "axe-core": "^4.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@axe-core/puppeteer": {
+          "optional": true
+        },
+        "axe-core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@ampproject/remapping": "2.2.0",
+        "@axe-core/puppeteer": "4.4.2",
         "@babel/core": "7.16.7",
         "@babel/preset-env": "7.16.8",
         "@babel/preset-typescript": "7.16.7",
@@ -41,6 +42,7 @@
         "@vue/compiler-sfc": "3.2.36",
         "ansi-regex": "6.0.1",
         "aria-query": "*",
+        "axe-core": "4.4.2",
         "babel-plugin-un-cjs": "2.5.0",
         "dom-accessibility-api": "0.5.14",
         "errorstacks": "2.4.0",
@@ -97,6 +99,21 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@axe-core/puppeteer": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.4.2.tgz",
+      "integrity": "sha512-HsiXUALjQ5fcWZZgGUvYGr/b7qvWbQXeDuW2z+2YYOJsavlPV9z0IGdm4rmX0lmsdJ9usA5vq5LNLiz23ZyXmw==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">=1.10.0 <= 13"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5509,6 +5526,15 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/babel-jest": {
@@ -20582,6 +20608,15 @@
       "integrity": "sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==",
       "dev": true
     },
+    "@axe-core/puppeteer": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.4.2.tgz",
+      "integrity": "sha512-HsiXUALjQ5fcWZZgGUvYGr/b7qvWbQXeDuW2z+2YYOJsavlPV9z0IGdm4rmX0lmsdJ9usA5vq5LNLiz23ZyXmw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.4.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -24789,6 +24824,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "axe-core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "dev": true
     },
     "babel-jest": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,18 @@
     "dist"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "@axe-core/puppeteer": "^4.4.2",
+    "axe-core": "^4.4.2"
+  },
+  "peerDependenciesMeta": {
+    "@axe-core/puppeteer": {
+      "optional": true
+    },
+    "axe-core": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@ampproject/remapping": "2.2.0",
     "@axe-core/puppeteer": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "@ampproject/remapping": "2.2.0",
+    "@axe-core/puppeteer": "4.4.2",
     "@babel/core": "7.16.7",
     "@babel/preset-env": "7.16.8",
     "@babel/preset-typescript": "7.16.7",
@@ -28,6 +29,7 @@
     "@vue/compiler-sfc": "3.2.36",
     "ansi-regex": "6.0.1",
     "aria-query": "*",
+    "axe-core": "4.4.2",
     "babel-plugin-un-cjs": "2.5.0",
     "dom-accessibility-api": "0.5.14",
     "errorstacks": "2.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ const external = [
   'esbuild',
   /postcss/,
   /mime/,
+  '@axe-core/puppeteer',
 ];
 
 /** @type {import('rollup').RollupOptions} */

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,7 +56,7 @@ const mainConfig = {
 const typesConfig = {
   input: 'src/index.ts',
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
-  external: [...external, 'polka'],
+  external: [...external, 'polka', 'axe-core'],
   plugins: [dts({ respectExternal: true })],
 };
 

--- a/src/accessibility/browser.ts
+++ b/src/accessibility/browser.ts
@@ -12,7 +12,7 @@ export * as colors from 'kolorist';
 export { printElement } from '../serialize';
 
 // We haver to tell kolorist to print the colors
-// beacuse by default it won't since we are in the browser
+// because by default it won't since we are in the browser
 // (the colored message gets sent to node to be printed)
 colors.options.enabled = true;
 colors.options.supportLevel = 1;

--- a/src/accessibility/browser.ts
+++ b/src/accessibility/browser.ts
@@ -6,6 +6,16 @@ import {
 // @ts-expect-error This is a fake file that triggers a rollup plugin
 import requiredOwnedElementsMap from 'generated:requiredOwnedElements';
 import type { AccessibilityTreeOptions } from '.';
+import * as colors from 'kolorist';
+
+export * as colors from 'kolorist';
+export { printElement } from '../serialize';
+
+// We haver to tell kolorist to print the colors
+// beacuse by default it won't since we are in the browser
+// (the colored message gets sent to node to be printed)
+colors.options.enabled = true;
+colors.options.supportLevel = 1;
 
 const indent = (text: string, indenter = '  ') =>
   indenter + text.split('\n').join(`\n${indenter}`);

--- a/src/accessibility/index.ts
+++ b/src/accessibility/index.ts
@@ -269,7 +269,7 @@ declare global {
   // eslint-disable-next-line @cloudfour/typescript-eslint/no-namespace
   namespace jest {
     interface Matchers<R> {
-      toPassAxeTests(): Promise<R>;
+      toPassAxeTests(opts?: ToPassAxeTestsOpts): Promise<R>;
     }
   }
 }

--- a/src/accessibility/index.ts
+++ b/src/accessibility/index.ts
@@ -110,9 +110,12 @@ async function formatViolations(violations: axe.Result[], page: Page) {
     // eslint-disable-next-line @cloudfour/unicorn/consistent-function-scoping
     const findElement = (node: axe.NodeResult) =>
       [...document.querySelectorAll(node.target as unknown as string)].find(
-        (el) => el.outerHTML === node.html,
+        (el) =>
+          el.outerHTML === node.html ||
+          // For long strings, axe-core returns only the opening tag
+          // https://github.com/dequelabs/axe-core/blob/v4.4.2/lib/core/utils/dq-element.js#L11
+          el.outerHTML.slice(0, el.outerHTML.indexOf('>') + 1) === node.html,
       );
-
     for (const { help, helpUrl, id, nodes } of violations) {
       // The dollar signs are used to indicate which part should be bolded/red
       // We can't directly call the color functions here since we haven't imported them

--- a/src/accessibility/index.ts
+++ b/src/accessibility/index.ts
@@ -4,15 +4,11 @@ import {
   assertElementHandle,
   jsHandleToArray,
   printColorsInErrorMessages,
+  removeFuncFromStackTrace,
 } from '../utils';
 import type { AsyncHookTracker } from '../async-hooks';
 import { activeAsyncHookTrackers } from '../async-hooks';
 import type axe from 'axe-core';
-
-/**
- * External dependencies
- */
-import AxePuppeteer from '@axe-core/puppeteer';
 
 const accessibilityTreeSymbol: unique symbol = Symbol('PT Accessibility Tree');
 
@@ -215,6 +211,18 @@ async function toPassAxeTests(
   page: Page,
   { include, exclude, disabledRules, options, config }: ToPassAxeTestsOpts = {},
 ): Promise<jest.CustomMatcherResult> {
+  let AxePuppeteer: typeof import('@axe-core/puppeteer').default;
+  try {
+    const axePuppeteerModule = await import('@axe-core/puppeteer');
+    AxePuppeteer = axePuppeteerModule.default;
+  } catch {
+    throw removeFuncFromStackTrace(
+      new Error(
+        'Install @axe-core/puppeteer and axe-core to use the toPassAxeTests matcher',
+      ),
+      toPassAxeTests,
+    );
+  }
   const axe = new AxePuppeteer(page);
 
   if (include) axe.include(include);

--- a/src/serialize/index.test.ts
+++ b/src/serialize/index.test.ts
@@ -162,4 +162,21 @@ describe('printElement', () => {
       `"<input required value=\\"\\" />"`,
     );
   });
+  it('truncates long attributes', () => {
+    const el = document.createElement('a');
+    el.setAttribute(
+      'href',
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
+    expect(printElement(el, false)).toMatchInlineSnapshot(
+      `"<a href=\\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[...]\\" />"`,
+    );
+  });
+  it('truncates <path d="..." /> very short', () => {
+    const el = document.createElement('path');
+    el.setAttribute('d', 'svgsvgsvgsvgsvgsvgsvgsvgsvgsvgsvgsvgsvgsvgsvgsvgsvg');
+    expect(printElement(el, false)).toMatchInlineSnapshot(
+      `"<path d=\\"svgsvgsvgsvgsvgsvgsvgsvgsvgsvg[...]\\" />"`,
+    );
+  });
 });

--- a/src/serialize/index.ts
+++ b/src/serialize/index.ts
@@ -151,9 +151,16 @@ export const printElement = (
         typeof el[attr.name as keyof Element] === 'boolean'
       )
         return highlight.attribute(attr.name);
+      const truncatedAttrValue =
+        // Special case: <path d="..." /> is unlikely to be useful so it is cut shorter
+        attr.value.length > 40 && attr.name === 'd' && tagName === 'path'
+          ? `${attr.value.slice(0, 30)}[...]`
+          : attr.value.length > 150
+          ? `${attr.value.slice(0, 150)}[...]`
+          : attr.value;
       return `${highlight.attribute(attr.name)}${highlight.equals(
         '=',
-      )}${highlight.string(`"${attr.value}"`)}`;
+      )}${highlight.string(`"${truncatedAttrValue}"`)}`;
     })
     .join(splitAttrs ? '\n  ' : ' ')}${
     selfClosing

--- a/src/serialize/index.ts
+++ b/src/serialize/index.ts
@@ -129,7 +129,7 @@ export const printElement = (
   const tagName = el.tagName.toLowerCase();
   const selfClosing = el.childNodes.length === 0;
   // We haver to tell kolorist to print the colors
-  // beacuse by default it won't since we are in the browser
+  // because by default it won't since we are in the browser
   // (the colored message gets sent to node to be printed)
   colors.options.enabled = true;
   colors.options.supportLevel = 1;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,13 +4,10 @@ import * as kolorist from 'kolorist';
 export const jsHandleToArray = async (arrayHandle: JSHandle) => {
   const properties = await arrayHandle.getProperties();
   const arr = Array.from({ length: properties.size });
-  for (let i = 0; i < properties.size; i++) {
-    const valHandle = properties.get(String(i));
-    if (valHandle) {
-      // Change primitives to live values rather than JSHandles
-      const val = await valHandle.jsonValue().catch(() => valHandle);
-      arr[i] = typeof val === 'object' ? valHandle : val;
-    }
+  for (const [i, valHandle] of properties.entries()) {
+    // Change primitives to live values rather than JSHandles
+    const val = await valHandle.jsonValue().catch(() => valHandle);
+    arr[Number(i)] = typeof val === 'object' ? valHandle : val;
   }
 
   return arr;

--- a/tests/accessibility/toPassAxeTests.test.ts
+++ b/tests/accessibility/toPassAxeTests.test.ts
@@ -60,6 +60,14 @@ test(
         "
       `);
     await expect(page).not.toPassAxeTests();
+    await expect(page).toPassAxeTests({
+      disabledRules: [
+        'image-alt',
+        'landmark-one-main',
+        'page-has-heading-one',
+        'region',
+      ],
+    });
     await utils.injectHTML(`
       <main>
         <h1>An example page</h1>

--- a/tests/accessibility/toPassAxeTests.test.ts
+++ b/tests/accessibility/toPassAxeTests.test.ts
@@ -58,7 +58,7 @@ test(
         Fix the following:
           • Some page content is not contained by landmarks
         "
-      `);
+    `);
     await expect(page).not.toPassAxeTests();
     await expect(page).toPassAxeTests({
       disabledRules: [
@@ -81,6 +81,80 @@ test(
 
         Expected page to contain accessibility check violations.
         No violations found."
+      `);
+
+    await utils.injectHTML(`
+      <svg viewBox="0 0 24 24" width="24" height="24" class="Icon Icon--large" role="img"><path d="M21.79,1H2.21A1.21,1.21,0,0,0,1,2.21V21.79A1.21,1.21,0,0,0,2.21,23H12.75V14.48H9.88V11.16h2.87V8.71A4,4,0,0,1,17,4.32a23.52,23.52,0,0,1,2.56.13v3H17.83A1.38,1.38,0,0,0,16.18,9v2.12h3.29L19,14.48H16.18V23h5.61A1.21,1.21,0,0,0,23,21.79V2.21A1.21,1.21,0,0,0,21.79,1Z"></path></svg>
     `);
+    // Axe-core shortens the returned HTML snippet for long elements
+    // This test makes sure that we are still able to find the real HTML in the DOM and use our custom formatting for the HTML
+    await expect(expect(page).toPassAxeTests()).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+        "[2mexpect([22m[31mpage[39m[2m).toPassAxeTests()[22m
+        Expected page to pass Axe accessibility tests.
+        Violations found:
+
+        [31m[1mDocument should have one main landmark[22m[39m (landmark-one-main)
+        https://dequeuniversity.com/rules/axe/4.4/landmark-one-main?application=axe-puppeteer
+        Affected Nodes:
+
+        <html lang=\\"en\\">
+          <head>[...]</head>
+          <body>
+            <svg
+              viewBox=\\"0 0 24 24\\"
+              width=\\"24\\"
+              height=\\"24\\"
+              class=\\"Icon Icon--large\\"
+              role=\\"img\\"
+            >
+              <path d=\\"M21.79,1H2.21A1.21,1.21,0,0,0,[...]\\" />
+            </svg>
+          </body>
+        </html>
+        Fix the following:
+          • Document does not have a main landmark.
+
+        [31m[1mPage should contain a level-one heading[22m[39m (page-has-heading-one)
+        https://dequeuniversity.com/rules/axe/4.4/page-has-heading-one?application=axe-puppeteer
+        Affected Nodes:
+
+        <html lang=\\"en\\">
+          <head>[...]</head>
+          <body>
+            <svg
+              viewBox=\\"0 0 24 24\\"
+              width=\\"24\\"
+              height=\\"24\\"
+              class=\\"Icon Icon--large\\"
+              role=\\"img\\"
+            >
+              <path d=\\"M21.79,1H2.21A1.21,1.21,0,0,0,[...]\\" />
+            </svg>
+          </body>
+        </html>
+        Fix the following:
+          • Page must have a level-one heading.
+
+        [31m[1m<svg> elements with an img role must have an alternative text[22m[39m (svg-img-alt)
+        https://dequeuniversity.com/rules/axe/4.4/svg-img-alt?application=axe-puppeteer
+        Affected Nodes:
+
+        <svg
+          viewBox=\\"0 0 24 24\\"
+          width=\\"24\\"
+          height=\\"24\\"
+          class=\\"Icon Icon--large\\"
+          role=\\"img\\"
+        >
+          <path d=\\"M21.79,1H2.21A1.21,1.21,0,0,0,[...]\\" />
+        </svg>
+        Fix any of the following:
+          • Element has no child that is a title
+          • aria-label attribute does not exist or is empty
+          • aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+          • Element has no title attribute
+        "
+      `);
   }),
 );

--- a/tests/accessibility/toPassAxeTests.test.ts
+++ b/tests/accessibility/toPassAxeTests.test.ts
@@ -1,0 +1,78 @@
+import { withBrowser } from 'pleasantest';
+
+test(
+  'Fails as expected and passes as expected',
+  withBrowser(async ({ utils, page }) => {
+    await utils.injectHTML(`
+      <img />
+    `);
+    await expect(expect(page).toPassAxeTests()).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+        "[2mexpect([22m[31mpage[39m[2m).toPassAxeTests()[22m
+        Expected page to pass Axe accessibility tests.
+        Violations found:
+
+        [31m[1mImages must have alternate text[22m[39m (image-alt)
+        https://dequeuniversity.com/rules/axe/4.4/image-alt?application=axe-puppeteer
+        Affected Nodes:
+
+        <img />
+        Fix any of the following:
+          • Element does not have an alt attribute
+          • aria-label attribute does not exist or is empty
+          • aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+          • Element has no title attribute
+          • Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
+
+        [31m[1mDocument should have one main landmark[22m[39m (landmark-one-main)
+        https://dequeuniversity.com/rules/axe/4.4/landmark-one-main?application=axe-puppeteer
+        Affected Nodes:
+
+        <html lang=\\"en\\">
+          <head>[...]</head>
+          <body>
+            <img />
+          </body>
+        </html>
+        Fix the following:
+          • Document does not have a main landmark.
+
+        [31m[1mPage should contain a level-one heading[22m[39m (page-has-heading-one)
+        https://dequeuniversity.com/rules/axe/4.4/page-has-heading-one?application=axe-puppeteer
+        Affected Nodes:
+
+        <html lang=\\"en\\">
+          <head>[...]</head>
+          <body>
+            <img />
+          </body>
+        </html>
+        Fix the following:
+          • Page must have a level-one heading.
+
+        [31m[1mAll page content should be contained by landmarks[22m[39m (region)
+        https://dequeuniversity.com/rules/axe/4.4/region?application=axe-puppeteer
+        Affected Nodes:
+
+        <img />
+        Fix the following:
+          • Some page content is not contained by landmarks
+        "
+      `);
+    await expect(page).not.toPassAxeTests();
+    await utils.injectHTML(`
+      <main>
+        <h1>An example page</h1>
+        <img alt="example image alt text"/>
+      </main>
+    `);
+    await expect(page).toPassAxeTests();
+    await expect(expect(page).not.toPassAxeTests()).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+        "[2mexpect([22m[31mpage[39m[2m).not.toPassAxeTests()[22m
+
+        Expected page to contain accessibility check violations.
+        No violations found."
+    `);
+  }),
+);


### PR DESCRIPTION
This assertion, based on [`jest-puppeteer-axe`](https://github.com/WordPress/gutenberg/tree/3b2eccc289cfc90bd99252b12fc4c6e470ce4c04/packages/jest-puppeteer-axe), allows you to check a page using the [axe accessibility linter](https://github.com/dequelabs/axe-core).

The output is a little nicer than jest-puppeteer-axe's because it shows the markup of the elements which are breaking axe rules (as opposed to a non-unique CSS selector), so it is easier to figure out which elements need to be fixed. In the browser, you can click on the markup to see the relevant elements in the devtools elements panel.

[Documentation](https://github.com/cloudfour/pleasantest/tree/to-pass-axe-tests#expectpagetopassaxetestsopts-topassaxetestsopts)

```js
test(
  'Axe tests',
  withBrowser(async ({ utils, page }) => {
    await utils.injectHTML(`
      <h1>Some html</h1>
    `);
    await expect(page).toPassAxeTests();
  }),
);
```

Here's what the output looks like in the CLI:

<img width="943" alt="Screen Shot 2022-06-02 at 8 45 29 AM" src="https://user-images.githubusercontent.com/13206945/171710881-f350d91a-d893-469b-b661-9fea5a4d21a5.png">

Here's what it looks like in the browser:

<img width="942" alt="Screen Shot 2022-06-02 at 8 45 53 AM" src="https://user-images.githubusercontent.com/13206945/171711024-4aee95bd-e1d8-4af2-b51d-a44c7337693a.png">

## Testing

Run the tests in watch mode:
```
git checkout to-pass-axe-tests
npm i
npm run build
npm run test:watch topassaxe
```

Note: the HTML syntax highlighting in the CLI output isn't shown when Pleasantest runs in its own test suite. This is so that the test snapshots are still readable and don't get covered with escape codes for coloring.

Test the browser output by changing [`tests/accessibility/toPassAxeTests.test.ts`](https://github.com/cloudfour/pleasantest/blob/to-pass-axe-tests/tests/accessibility/toPassAxeTests.test.ts) to use `withBrowser.headed` instead of `withBrowser`. Then it should open a browser for the test, and close it once it passes. To make the test fail so you can see the failure message in the browser, under the `utils.injectHTML(...)` line add a new line:
```js
await expect(page).toPassAxeTests()
```