### PR TITLE
Drop support for node 12 and 17

### DIFF
--- a/.changeset/tasty-hounds-begin.md
+++ b/.changeset/tasty-hounds-begin.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': major
+---
+
+Drop support for Node 12 and 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@testing-library/dom": "8.13.0",
         "@testing-library/jest-dom": "5.15.1",
         "@types/jest": "28.1.1",
-        "@types/node": "12.20.55",
+        "@types/node": "14.18.21",
         "@types/polka": "0.5.4",
         "@types/puppeteer": "5.4.6",
         "@vue/compiler-sfc": "3.2.36",
@@ -76,7 +76,7 @@
         "vue": "3.2.36"
       },
       "engines": {
-        "node": "^12.2 || 14 || 16 || 17 || 18"
+        "node": "^14.18.0 || 16 || 18"
       },
       "peerDependencies": {
         "@axe-core/puppeteer": "^4.4.2",
@@ -4013,6 +4013,12 @@
         "fs-extra": "^8.1.0"
       }
     },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true
+    },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -4679,9 +4685,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "14.18.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.21.tgz",
+      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==",
       "devOptional": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -23702,6 +23708,12 @@
         "fs-extra": "^8.1.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -24264,9 +24276,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "14.18.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.21.tgz",
+      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==",
       "devOptional": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pleasantest",
   "version": "2.2.0",
   "engines": {
-    "node": "^12.2 || 14 || 16 || 17 || 18"
+    "node": "^14.18.0 || 16 || 18"
   },
   "files": [
     "dist"
@@ -35,7 +35,7 @@
     "@testing-library/dom": "8.13.0",
     "@testing-library/jest-dom": "5.15.1",
     "@types/jest": "28.1.1",
-    "@types/node": "12.20.55",
+    "@types/node": "14.18.21",
     "@types/polka": "0.5.4",
     "@types/puppeteer": "5.4.6",
     "@vue/compiler-sfc": "3.2.36",

--- a/src/module-server/bundle-npm-module.ts
+++ b/src/module-server/bundle-npm-module.ts
@@ -5,7 +5,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import { environmentVariablesPlugin } from './plugins/environment-variables-plugin';
 import * as esbuild from 'esbuild';
 import { parse } from 'cjs-module-lexer';
-// @ts-expect-error @types/node@12 doesn't like this import
 import { createRequire } from 'module';
 import { isBareImport } from './extensions-and-detection';
 let npmCache: RollupCache | undefined;

--- a/src/module-server/node-resolve.test.ts
+++ b/src/module-server/node-resolve.test.ts
@@ -10,11 +10,7 @@ const createdPaths: string[] = [];
 afterAll(async () => {
   await Promise.all(
     createdPaths.map(async (path) => {
-      // For node 12, fs.rm() is not supported.
-      // For node 16, fs.rmdir() with recursive is deprecated (but still works)
-      // When we drop support for node 12, switch to below line for fs.rm()
-      await fs.rmdir(path, { recursive: true });
-      // Await fs.rm(path, { recursive: true, force: true });
+      await fs.rm(path, { recursive: true, force: true });
     }),
   );
 });


### PR DESCRIPTION
They are both end-of-life: https://nodejs.org/en/about/releases/