### PR TITLE
Change imports to real ESM

### DIFF
--- a/examples/menu/index.test.ts
+++ b/examples/menu/index.test.ts
@@ -1,8 +1,9 @@
-import type { PleasantestUtils } from 'pleasantest';
-import { getAccessibilityTree, withBrowser, devices } from 'pleasantest';
+import * as path from 'node:path';
 
 import { Liquid } from 'liquidjs';
-import * as path from 'path';
+import type { PleasantestUtils } from 'pleasantest';
+import { devices, getAccessibilityTree, withBrowser } from 'pleasantest';
+
 const iPhone = devices['iPhone 11'];
 
 // This particular example uses Liquid to load templates with data,

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,6 +2,10 @@ module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: {
     '^pleasantest$': '<rootDir>/dist/cjs/index.cjs',
+    // Since TS requires that relative imports to .ts files use the .js extension in the import,
+    // this line is needed to tell Jest that when a .js file is imported,
+    // it may need to look for the corresponding .ts file on disk.
+    '^(.+)\\.js$': ['$1.js', '$1.ts'],
   },
   testRunner: 'jest-circus/runner',
   watchPathIgnorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@babel/preset-typescript": "7.16.7",
         "@changesets/changelog-github": "0.4.5",
         "@changesets/cli": "2.23.0",
-        "@cloudfour/eslint-plugin": "19.0.0",
+        "@cloudfour/eslint-plugin": "20.0.2",
         "@rollup/plugin-alias": "3.1.9",
         "@rollup/plugin-babel": "5.3.1",
         "@rollup/plugin-node-resolve": "13.3.0",
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@cloudfour/eslint-plugin": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@cloudfour/eslint-plugin/-/eslint-plugin-19.0.0.tgz",
-      "integrity": "sha512-01OKilV6O+AMF3ODrZKATTcOKy9UHYGfm+sEj3hng6nyUkLgIbDsVXqu6jR+K1INSzP+vxVoEnlQeAYAgCz0Mw==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudfour/eslint-plugin/-/eslint-plugin-20.0.2.tgz",
+      "integrity": "sha512-Cv7Kd3FE3aYmC8gbxd7Adi0bWhCv9Vtqc7iz0CbSVixNc3nUcdUW19WjbpNNZ4tnAVVfngphoCE3LJbGoxdxJQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.13.10",
@@ -2197,7 +2197,7 @@
         "@typescript-eslint/parser": "^5.0.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsdoc": "^39.0.0",
-        "eslint-plugin-n": "^15.0.1",
+        "eslint-plugin-n": "^15.2.3",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-unicorn": "^42.0.0"
       },
@@ -4667,12 +4667,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -4787,6 +4781,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -6863,36 +6863,36 @@
       "dev": true
     },
     "node_modules/csv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.0.tgz",
-      "integrity": "sha512-32tcuxdb4HW3zbk8NBcVQb8/7xuJB5sv+q4BuQ6++E/K6JvHvWoCHcGzB5Au95vVikNH4ztE0XNC/Bws950cfA==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
+      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
       "dev": true,
       "dependencies": {
-        "csv-generate": "^3.4.0",
-        "csv-parse": "^4.15.3",
-        "csv-stringify": "^5.6.2",
-        "stream-transform": "^2.1.0"
+        "csv-generate": "^3.4.3",
+        "csv-parse": "^4.16.3",
+        "csv-stringify": "^5.6.5",
+        "stream-transform": "^2.1.3"
       },
       "engines": {
         "node": ">= 0.1.90"
       }
     },
     "node_modules/csv-generate": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.0.tgz",
-      "integrity": "sha512-D6yi7c6lL70cpTx3TQIVWKrfxuLiKa0pBizu0zi7fSRXlhmE7u674gk9k1IjCEnxKq2t6xzbXnxcOmSdBbE8vQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
+      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==",
       "dev": true
     },
     "node_modules/csv-parse": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.4.tgz",
-      "integrity": "sha512-OdBbFc0yZhOm17lSxqkirrHlFFVpKRT0wp4DAGoJelsP3LbGzV9LNr7XmM/lrr0uGkCtaqac9UhP8PDHXOAbMg==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
       "dev": true
     },
     "node_modules/csv-stringify": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.2.tgz",
-      "integrity": "sha512-n3rIVbX6ylm1YsX2NEug9IaPV8xRnT+9/NNZbrA/bcHgOSSeqtWla6XnI/xmyu57wIw+ASCAoX1oM6EZtqJV0A==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
+      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
     },
     "node_modules/data-urls": {
@@ -7406,36 +7406,6 @@
         "esbuild-windows-arm64": "0.14.43"
       }
     },
-    "node_modules/esbuild-android-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.43.tgz",
-      "integrity": "sha512-kqFXAS72K6cNrB6RiM7YJ5lNvmWRDSlpi7ZuRZ1hu1S3w0zlwcoCxWAyM23LQUyZSs1PbjHgdbbfYAN8IGh6xg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.43.tgz",
-      "integrity": "sha512-bKS2BBFh+7XZY9rpjiHGRNA7LvWYbZWP87pLehggTG7tTaCDvj8qQGOU/OZSjCSKDYbgY7Q+oDw8RlYQ2Jt2BA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/esbuild-darwin-64": {
       "version": "0.14.43",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.43.tgz",
@@ -7446,51 +7416,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.43.tgz",
-      "integrity": "sha512-1HyFUKs8DMCBOvw1Qxpr5Vv/ThNcVIFb5xgXWK3pyT40WPvgYIiRTwJCvNs4l8i5qWF8/CK5bQxJVDjQvtv0Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.43.tgz",
-      "integrity": "sha512-FNWc05TPHYgaXjbPZO5/rJKSBslfG6BeMSs8GhwnqAKP56eEhvmzwnIz1QcC9cRVyO+IKqWNfmHFkCa1WJTULA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.43.tgz",
-      "integrity": "sha512-amrYopclz3VohqisOPR6hA3GOWA3LZC1WDLnp21RhNmoERmJ/vLnOpnrG2P/Zao+/erKTCUqmrCIPVtj58DRoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
       ],
       "engines": {
         "node": ">=12"
@@ -7508,216 +7433,6 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.8.50"
-      }
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.43.tgz",
-      "integrity": "sha512-KoxoEra+9O3AKVvgDFvDkiuddCds6q71owSQEYwjtqRV7RwbPzKxJa6+uyzUulHcyGVq0g15K0oKG5CFBcvYDw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.43.tgz",
-      "integrity": "sha512-EwINwGMyiJMgBby5/SbMqKcUhS5AYAZ2CpEBzSowsJPNBJEdhkCTtEjk757TN/wxgbu3QklqDM6KghY660QCUw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.43.tgz",
-      "integrity": "sha512-e6YzQUoDxxtyamuF12eVzzRC7bbEFSZohJ6igQB9tBqnNmIQY3fI6Cns3z2wxtbZ3f2o6idkD2fQnlvs2902Dg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.43.tgz",
-      "integrity": "sha512-UlSpjMWllAc70zYbHxWuDS3FJytyuR/gHJYBr8BICcTNb/TSOYVBg6U7b3jZ3mILTrgzwJUHwhEwK18FZDouUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.43.tgz",
-      "integrity": "sha512-f+v8cInPEL1/SDP//CfSYzcDNgE4CY3xgDV81DWm3KAPWzhvxARrKxB1Pstf5mB56yAslJDxu7ryBUPX207EZA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.43.tgz",
-      "integrity": "sha512-5wZYMDGAL/K2pqkdIsW+I4IR41kyfHr/QshJcNpUfK3RjB3VQcPWOaZmc+74rm4ZjVirYrtz+jWw0SgxtxRanA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.43.tgz",
-      "integrity": "sha512-lYcAOUxp85hC7lSjycJUVSmj4/9oEfSyXjb/ua9bNl8afonaduuqtw7hvKMoKuYnVwOCDw4RSfKpcnIRDWq+Bw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.43.tgz",
-      "integrity": "sha512-27e43ZhHvhFE4nM7HqtUbMRu37I/4eNSUbb8FGZWszV+uLzMIsHDwLoBiJmw7G9N+hrehNPeQ4F5Ujad0DrUKQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.43.tgz",
-      "integrity": "sha512-2mH4QF6hHBn5zzAfxEI/2eBC0mspVsZ6UVo821LpAJKMvLJPBk3XJO5xwg7paDqSqpl7p6IRrAenW999AEfJhQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.43.tgz",
-      "integrity": "sha512-ZhQpiZjvqCqO8jKdGp9+8k9E/EHSA+zIWOg+grwZasI9RoblqJ1QiZqqi7jfd6ZrrG1UFBNGe4m0NFxCFbMVbg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.43.tgz",
-      "integrity": "sha512-DgxSi9DaHReL9gYuul2rrQCAapgnCJkh3LSHPKsY26zytYppG0HgkgVF80zjIlvEsUbGBP/GHQzBtrezj/Zq1Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.43.tgz",
-      "integrity": "sha512-Ih3+2O5oExiqm0mY6YYE5dR0o8+AspccQ3vIAtRodwFvhuyGLjb0Hbmzun/F3Lw19nuhPMu3sW2fqIJ5xBxByw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.43.tgz",
-      "integrity": "sha512-8NsuNfI8xwFuJbrCuI+aBqNTYkrWErejFO5aYM+yHqyHuL8mmepLS9EPzAzk8rvfaJrhN0+RvKWAcymViHOKEw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.43.tgz",
-      "integrity": "sha512-7ZlD7bo++kVRblJEoG+cepljkfP8bfuTPz5fIXzptwnPaFwGS6ahvfoYzY7WCf5v/1nX2X02HDraVItTgbHnKw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/escalade": {
@@ -8135,19 +7850,19 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.1.0.tgz",
-      "integrity": "sha512-Tgx4Z58QXv2Ha7Qzp0u4wavnZNZ3AOievZMxrAxi7nvDbzD5B/JqOD80LHYcGHFZc2HD9jDmM/+KWMPov46a4A==",
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.3.tgz",
+      "integrity": "sha512-H+KC7U5R+3IWTeRnACm/4wlqLvS1Q7M6t7BGhn89qXDkZan8HTAEv3ouIONA0ifDwc2YzPFmyPzHuNLddNK4jw==",
       "dev": true,
       "dependencies": {
-        "builtins": "^4.0.0",
+        "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
         "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "is-core-module": "^2.3.0",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.3.0"
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": ">=12.22.0"
@@ -8157,6 +7872,30 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-promise": {
@@ -10097,9 +9836,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -15194,9 +14933,9 @@
       }
     },
     "node_modules/mixme": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.1.tgz",
-      "integrity": "sha512-NaeZIckeBFT7i0XBEpGyFcAE0/bLcQ9MHErTpnU3bLWVE5WZbxG5Y3fDsMxYGifTo5khDA42OquXCC2ngKJB+g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
+      "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==",
       "dev": true,
       "engines": {
         "node": ">= 8.0.0"
@@ -18854,12 +18593,12 @@
       }
     },
     "node_modules/stream-transform": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.0.tgz",
-      "integrity": "sha512-bwQO+75rzQbug7e5OOHnOR3FgbJ0fCjHmDIdynkwUaFzleBXugGmv2dx3sX3aIHUQRLjrcisRPgN9BWl63uGgw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
+      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
       "dev": true,
       "dependencies": {
-        "mixme": "^0.5.0"
+        "mixme": "^0.5.1"
       }
     },
     "node_modules/string_decoder": {
@@ -22340,9 +22079,9 @@
       }
     },
     "@cloudfour/eslint-plugin": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@cloudfour/eslint-plugin/-/eslint-plugin-19.0.0.tgz",
-      "integrity": "sha512-01OKilV6O+AMF3ODrZKATTcOKy9UHYGfm+sEj3hng6nyUkLgIbDsVXqu6jR+K1INSzP+vxVoEnlQeAYAgCz0Mw==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudfour/eslint-plugin/-/eslint-plugin-20.0.2.tgz",
+      "integrity": "sha512-Cv7Kd3FE3aYmC8gbxd7Adi0bWhCv9Vtqc7iz0CbSVixNc3nUcdUW19WjbpNNZ4tnAVVfngphoCE3LJbGoxdxJQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",
@@ -22350,7 +22089,7 @@
         "@typescript-eslint/parser": "^5.0.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsdoc": "^39.0.0",
-        "eslint-plugin-n": "^15.0.1",
+        "eslint-plugin-n": "^15.2.3",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-unicorn": "^42.0.0"
       }
@@ -24308,12 +24047,6 @@
         "@types/unist": "*"
       }
     },
-    "@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
-    },
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -24427,6 +24160,14 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/mime": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+          "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+          "dev": true
+        }
       }
     },
     "@types/stack-utils": {
@@ -26015,33 +25756,33 @@
       "dev": true
     },
     "csv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.0.tgz",
-      "integrity": "sha512-32tcuxdb4HW3zbk8NBcVQb8/7xuJB5sv+q4BuQ6++E/K6JvHvWoCHcGzB5Au95vVikNH4ztE0XNC/Bws950cfA==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
+      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
       "dev": true,
       "requires": {
-        "csv-generate": "^3.4.0",
-        "csv-parse": "^4.15.3",
-        "csv-stringify": "^5.6.2",
-        "stream-transform": "^2.1.0"
+        "csv-generate": "^3.4.3",
+        "csv-parse": "^4.16.3",
+        "csv-stringify": "^5.6.5",
+        "stream-transform": "^2.1.3"
       }
     },
     "csv-generate": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.0.tgz",
-      "integrity": "sha512-D6yi7c6lL70cpTx3TQIVWKrfxuLiKa0pBizu0zi7fSRXlhmE7u674gk9k1IjCEnxKq2t6xzbXnxcOmSdBbE8vQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
+      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==",
       "dev": true
     },
     "csv-parse": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.4.tgz",
-      "integrity": "sha512-OdBbFc0yZhOm17lSxqkirrHlFFVpKRT0wp4DAGoJelsP3LbGzV9LNr7XmM/lrr0uGkCtaqac9UhP8PDHXOAbMg==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
       "dev": true
     },
     "csv-stringify": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.2.tgz",
-      "integrity": "sha512-n3rIVbX6ylm1YsX2NEug9IaPV8xRnT+9/NNZbrA/bcHgOSSeqtWla6XnI/xmyu57wIw+ASCAoX1oM6EZtqJV0A==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
+      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
     },
     "data-urls": {
@@ -26439,40 +26180,10 @@
         "esbuild-windows-arm64": "0.14.43"
       }
     },
-    "esbuild-android-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.43.tgz",
-      "integrity": "sha512-kqFXAS72K6cNrB6RiM7YJ5lNvmWRDSlpi7ZuRZ1hu1S3w0zlwcoCxWAyM23LQUyZSs1PbjHgdbbfYAN8IGh6xg==",
-      "optional": true
-    },
-    "esbuild-android-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.43.tgz",
-      "integrity": "sha512-bKS2BBFh+7XZY9rpjiHGRNA7LvWYbZWP87pLehggTG7tTaCDvj8qQGOU/OZSjCSKDYbgY7Q+oDw8RlYQ2Jt2BA==",
-      "optional": true
-    },
     "esbuild-darwin-64": {
       "version": "0.14.43",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.43.tgz",
       "integrity": "sha512-/3PSilx011ttoieRGkSZ0XV8zjBf2C9enV4ScMMbCT4dpx0mFhMOpFnCHkOK0pWGB8LklykFyHrWk2z6DENVUg==",
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.43.tgz",
-      "integrity": "sha512-1HyFUKs8DMCBOvw1Qxpr5Vv/ThNcVIFb5xgXWK3pyT40WPvgYIiRTwJCvNs4l8i5qWF8/CK5bQxJVDjQvtv0Yw==",
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.43.tgz",
-      "integrity": "sha512-FNWc05TPHYgaXjbPZO5/rJKSBslfG6BeMSs8GhwnqAKP56eEhvmzwnIz1QcC9cRVyO+IKqWNfmHFkCa1WJTULA==",
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.43.tgz",
-      "integrity": "sha512-amrYopclz3VohqisOPR6hA3GOWA3LZC1WDLnp21RhNmoERmJ/vLnOpnrG2P/Zao+/erKTCUqmrCIPVtj58DRoA==",
       "optional": true
     },
     "esbuild-jest": {
@@ -26485,90 +26196,6 @@
         "@babel/plugin-transform-modules-commonjs": "^7.12.13",
         "babel-jest": "^26.6.3"
       }
-    },
-    "esbuild-linux-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.43.tgz",
-      "integrity": "sha512-KoxoEra+9O3AKVvgDFvDkiuddCds6q71owSQEYwjtqRV7RwbPzKxJa6+uyzUulHcyGVq0g15K0oKG5CFBcvYDw==",
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.43.tgz",
-      "integrity": "sha512-EwINwGMyiJMgBby5/SbMqKcUhS5AYAZ2CpEBzSowsJPNBJEdhkCTtEjk757TN/wxgbu3QklqDM6KghY660QCUw==",
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.43.tgz",
-      "integrity": "sha512-e6YzQUoDxxtyamuF12eVzzRC7bbEFSZohJ6igQB9tBqnNmIQY3fI6Cns3z2wxtbZ3f2o6idkD2fQnlvs2902Dg==",
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.43.tgz",
-      "integrity": "sha512-UlSpjMWllAc70zYbHxWuDS3FJytyuR/gHJYBr8BICcTNb/TSOYVBg6U7b3jZ3mILTrgzwJUHwhEwK18FZDouUQ==",
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.43.tgz",
-      "integrity": "sha512-f+v8cInPEL1/SDP//CfSYzcDNgE4CY3xgDV81DWm3KAPWzhvxARrKxB1Pstf5mB56yAslJDxu7ryBUPX207EZA==",
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.43.tgz",
-      "integrity": "sha512-5wZYMDGAL/K2pqkdIsW+I4IR41kyfHr/QshJcNpUfK3RjB3VQcPWOaZmc+74rm4ZjVirYrtz+jWw0SgxtxRanA==",
-      "optional": true
-    },
-    "esbuild-linux-riscv64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.43.tgz",
-      "integrity": "sha512-lYcAOUxp85hC7lSjycJUVSmj4/9oEfSyXjb/ua9bNl8afonaduuqtw7hvKMoKuYnVwOCDw4RSfKpcnIRDWq+Bw==",
-      "optional": true
-    },
-    "esbuild-linux-s390x": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.43.tgz",
-      "integrity": "sha512-27e43ZhHvhFE4nM7HqtUbMRu37I/4eNSUbb8FGZWszV+uLzMIsHDwLoBiJmw7G9N+hrehNPeQ4F5Ujad0DrUKQ==",
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.43.tgz",
-      "integrity": "sha512-2mH4QF6hHBn5zzAfxEI/2eBC0mspVsZ6UVo821LpAJKMvLJPBk3XJO5xwg7paDqSqpl7p6IRrAenW999AEfJhQ==",
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.43.tgz",
-      "integrity": "sha512-ZhQpiZjvqCqO8jKdGp9+8k9E/EHSA+zIWOg+grwZasI9RoblqJ1QiZqqi7jfd6ZrrG1UFBNGe4m0NFxCFbMVbg==",
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.43.tgz",
-      "integrity": "sha512-DgxSi9DaHReL9gYuul2rrQCAapgnCJkh3LSHPKsY26zytYppG0HgkgVF80zjIlvEsUbGBP/GHQzBtrezj/Zq1Q==",
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.43.tgz",
-      "integrity": "sha512-Ih3+2O5oExiqm0mY6YYE5dR0o8+AspccQ3vIAtRodwFvhuyGLjb0Hbmzun/F3Lw19nuhPMu3sW2fqIJ5xBxByw==",
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.43.tgz",
-      "integrity": "sha512-8NsuNfI8xwFuJbrCuI+aBqNTYkrWErejFO5aYM+yHqyHuL8mmepLS9EPzAzk8rvfaJrhN0+RvKWAcymViHOKEw==",
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.14.43",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.43.tgz",
-      "integrity": "sha512-7ZlD7bo++kVRblJEoG+cepljkfP8bfuTPz5fIXzptwnPaFwGS6ahvfoYzY7WCf5v/1nX2X02HDraVItTgbHnKw==",
-      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -27001,19 +26628,39 @@
       }
     },
     "eslint-plugin-n": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.1.0.tgz",
-      "integrity": "sha512-Tgx4Z58QXv2Ha7Qzp0u4wavnZNZ3AOievZMxrAxi7nvDbzD5B/JqOD80LHYcGHFZc2HD9jDmM/+KWMPov46a4A==",
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.3.tgz",
+      "integrity": "sha512-H+KC7U5R+3IWTeRnACm/4wlqLvS1Q7M6t7BGhn89qXDkZan8HTAEv3ouIONA0ifDwc2YzPFmyPzHuNLddNK4jw==",
       "dev": true,
       "requires": {
-        "builtins": "^4.0.0",
+        "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
         "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "is-core-module": "^2.3.0",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.3.0"
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "builtins": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+          "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-promise": {
@@ -28370,9 +28017,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -32166,9 +31813,9 @@
       }
     },
     "mixme": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.1.tgz",
-      "integrity": "sha512-NaeZIckeBFT7i0XBEpGyFcAE0/bLcQ9MHErTpnU3bLWVE5WZbxG5Y3fDsMxYGifTo5khDA42OquXCC2ngKJB+g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
+      "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==",
       "dev": true
     },
     "mkdirp": {
@@ -34926,12 +34573,12 @@
       }
     },
     "stream-transform": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.0.tgz",
-      "integrity": "sha512-bwQO+75rzQbug7e5OOHnOR3FgbJ0fCjHmDIdynkwUaFzleBXugGmv2dx3sX3aIHUQRLjrcisRPgN9BWl63uGgw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
+      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
       "dev": true,
       "requires": {
-        "mixme": "^0.5.0"
+        "mixme": "^0.5.1"
       }
     },
     "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@testing-library/dom": "8.13.0",
         "@testing-library/jest-dom": "5.15.1",
         "@types/jest": "28.1.1",
+        "@types/mime": "2.0.3",
         "@types/node": "14.18.21",
         "@types/polka": "0.5.4",
         "@types/puppeteer": "5.4.6",
@@ -4666,6 +4667,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
@@ -24046,6 +24053,12 @@
       "requires": {
         "@types/unist": "*"
       }
+    },
+    "@types/mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@testing-library/dom": "8.13.0",
     "@testing-library/jest-dom": "5.15.1",
     "@types/jest": "28.1.1",
+    "@types/mime": "2.0.3",
     "@types/node": "14.18.21",
     "@types/polka": "0.5.4",
     "@types/puppeteer": "5.4.6",
@@ -144,5 +145,6 @@
       "remark-lint-no-dead-urls"
     ]
   },
-  "repository": "cloudfour/pleasantest"
+  "repository": "cloudfour/pleasantest",
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/preset-typescript": "7.16.7",
     "@changesets/changelog-github": "0.4.5",
     "@changesets/cli": "2.23.0",
-    "@cloudfour/eslint-plugin": "19.0.0",
+    "@cloudfour/eslint-plugin": "20.0.2",
     "@rollup/plugin-alias": "3.1.9",
     "@rollup/plugin-babel": "5.3.1",
     "@rollup/plugin-node-resolve": "13.3.0",
@@ -120,7 +120,8 @@
   "main": "./dist/cjs/index.cjs",
   "exports": {
     "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": "./dist/esm/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,12 @@
+import babel from '@rollup/plugin-babel';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import dts from 'rollup-plugin-dts';
+
+import accessibilityConfig from './src/accessibility/rollup.config.js';
 import jestDomConfig from './src/jest-dom/rollup.config.js';
 import pptrTestingLibraryConfig from './src/pptr-testing-library-client/rollup.config.js';
 import userUtilsConfig from './src/user-util/rollup.config.js';
-import accessibilityConfig from './src/accessibility/rollup.config.js';
 
-import dts from 'rollup-plugin-dts';
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
 const extensions = ['.js', '.jsx', '.es6', '.es', '.mjs', '.ts', '.tsx'];
 
 const external = [

--- a/src/accessibility/browser.ts
+++ b/src/accessibility/browser.ts
@@ -7,10 +7,10 @@ import {
 import requiredOwnedElementsMap from 'generated:requiredOwnedElements';
 import * as colors from 'kolorist';
 
-import type { AccessibilityTreeOptions } from '.';
+import type { AccessibilityTreeOptions } from './index.js';
 
 export * as colors from 'kolorist';
-export { printElement } from '../serialize';
+export { printElement } from '../serialize/index.js';
 
 // We haver to tell kolorist to print the colors
 // because by default it won't since we are in the browser

--- a/src/accessibility/browser.ts
+++ b/src/accessibility/browser.ts
@@ -1,12 +1,13 @@
 import {
-  getRole,
-  computeAccessibleName,
   computeAccessibleDescription,
+  computeAccessibleName,
+  getRole,
 } from 'dom-accessibility-api';
 // @ts-expect-error This is a fake file that triggers a rollup plugin
 import requiredOwnedElementsMap from 'generated:requiredOwnedElements';
-import type { AccessibilityTreeOptions } from '.';
 import * as colors from 'kolorist';
+
+import type { AccessibilityTreeOptions } from '.';
 
 export * as colors from 'kolorist';
 export { printElement } from '../serialize';

--- a/src/accessibility/index.ts
+++ b/src/accessibility/index.ts
@@ -1,14 +1,15 @@
+import type axe from 'axe-core';
 import type { ElementHandle, Page, Serializable } from 'puppeteer';
-import { createClientRuntimeServer } from '../module-server/client-runtime-server';
+
+import type { AsyncHookTracker } from '../async-hooks.js';
+import { activeAsyncHookTrackers } from '../async-hooks.js';
+import { createClientRuntimeServer } from '../module-server/client-runtime-server.js';
 import {
   assertElementHandle,
   jsHandleToArray,
   printColorsInErrorMessages,
   removeFuncFromStackTrace,
-} from '../utils';
-import type { AsyncHookTracker } from '../async-hooks';
-import { activeAsyncHookTrackers } from '../async-hooks';
-import type axe from 'axe-core';
+} from '../utils.js';
 
 const accessibilityTreeSymbol: unique symbol = Symbol('PT Accessibility Tree');
 

--- a/src/accessibility/index.ts
+++ b/src/accessibility/index.ts
@@ -218,7 +218,7 @@ async function toPassAxeTests(
   let AxePuppeteer: typeof import('@axe-core/puppeteer').default;
   try {
     const axePuppeteerModule = await import('@axe-core/puppeteer');
-    AxePuppeteer = axePuppeteerModule.default;
+    AxePuppeteer = axePuppeteerModule.AxePuppeteer;
   } catch {
     throw removeFuncFromStackTrace(
       new Error(

--- a/src/accessibility/rollup.config.js
+++ b/src/accessibility/rollup.config.js
@@ -1,8 +1,9 @@
 import babel from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import { terser } from 'rollup-plugin-terser';
-import { rollupPluginDomAccessibilityApi } from '../rollup-plugin-dom-accessibility-api.js';
 import * as r from 'aria-query';
+import { terser } from 'rollup-plugin-terser';
+
+import { rollupPluginDomAccessibilityApi } from '../rollup-plugin-dom-accessibility-api.js';
 
 const extensions = ['.js', '.jsx', '.es6', '.es', '.mjs', '.ts', '.tsx'];
 

--- a/src/ansi-colors-browser.test.ts
+++ b/src/ansi-colors-browser.test.ts
@@ -1,5 +1,9 @@
 import * as colors from 'kolorist';
-import { ansiColorsLog, colors as browserColors } from './ansi-colors-browser';
+
+import {
+  ansiColorsLog,
+  colors as browserColors,
+} from './ansi-colors-browser.js';
 
 // For some reason the tests fail without this
 colors.options.enabled = true;

--- a/src/async-hooks.ts
+++ b/src/async-hooks.ts
@@ -5,7 +5,7 @@
  * so we should throw an error that indicates that.
  */
 
-import { removeFuncFromStackTrace } from './utils';
+import { removeFuncFromStackTrace } from './utils.js';
 
 /**
  * Set of all active async hook trackers

--- a/src/connect-to-browser.ts
+++ b/src/connect-to-browser.ts
@@ -1,10 +1,11 @@
-import * as childProcess from 'child_process';
-import * as path from 'path';
-import { promises as fs } from 'fs';
+import * as childProcess from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import startDisownedBrowserPath from 'bundle:./start-disowned-browser';
 import * as puppeteer from 'puppeteer';
 // @ts-expect-error the bundle: syntax is from a plugin in the rollup config and TS does not know about it
-import startDisownedBrowserPath from 'bundle:./start-disowned-browser';
-import { fileURLToPath } from 'url';
 
 // This is the folder that Pleasantest is installed in (e.g. <something>/node_modules/pleasantest)
 const installFolder = path.dirname(

--- a/src/connect-to-browser.ts
+++ b/src/connect-to-browser.ts
@@ -3,9 +3,9 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// @ts-expect-error the bundle: syntax is from a plugin in the rollup config and TS does not know about it
 import startDisownedBrowserPath from 'bundle:./start-disowned-browser';
 import * as puppeteer from 'puppeteer';
-// @ts-expect-error the bundle: syntax is from a plugin in the rollup config and TS does not know about it
 
 // This is the folder that Pleasantest is installed in (e.g. <something>/node_modules/pleasantest)
 const installFolder = path.dirname(

--- a/src/extend-expect.ts
+++ b/src/extend-expect.ts
@@ -3,7 +3,7 @@ import type { ElementHandle, JSHandle } from 'puppeteer';
 import type { AsyncHookTracker } from './async-hooks.js';
 import { activeAsyncHookTrackers } from './async-hooks.js';
 import { createClientRuntimeServer } from './module-server/client-runtime-server.js';
-import { deserialize, serialize } from './serialize';
+import { deserialize, serialize } from './serialize/index.js';
 import {
   isElementHandle,
   isPromise,

--- a/src/extend-expect.ts
+++ b/src/extend-expect.ts
@@ -1,7 +1,8 @@
 import type { ElementHandle, JSHandle } from 'puppeteer';
-import type { AsyncHookTracker } from './async-hooks';
-import { activeAsyncHookTrackers } from './async-hooks';
-import { createClientRuntimeServer } from './module-server/client-runtime-server';
+
+import type { AsyncHookTracker } from './async-hooks.js';
+import { activeAsyncHookTrackers } from './async-hooks.js';
+import { createClientRuntimeServer } from './module-server/client-runtime-server.js';
 import { deserialize, serialize } from './serialize';
 import {
   isElementHandle,
@@ -9,7 +10,7 @@ import {
   jsHandleToArray,
   printColorsInErrorMessages,
   removeFuncFromStackTrace,
-} from './utils';
+} from './utils.js';
 
 const methods = [
   'toBeInTheDocument',

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,10 @@ import { ansiColorsLog } from './ansi-colors-browser.js';
 import type { AsyncHookTracker } from './async-hooks.js';
 import { createAsyncHookTracker } from './async-hooks.js';
 import { connectToBrowser } from './connect-to-browser.js';
-import type { ModuleServerOpts } from './module-server';
-import { createModuleServer } from './module-server';
 import { createBuildStatusTracker } from './module-server/build-status-tracker.js';
 import { cleanupClientRuntimeServer } from './module-server/client-runtime-server.js';
+import type { ModuleServerOpts } from './module-server/index.js';
+import { createModuleServer } from './module-server/index.js';
 import type { BoundQueries, WaitForOptions } from './pptr-testing-library.js';
 import {
   getQueriesForElement,
@@ -493,7 +493,7 @@ afterAll(async () => {
 export {
   getAccessibilityTree,
   accessibilityTreeSnapshotSerializer,
-} from './accessibility';
+} from './accessibility/index.js';
 
 export { type PleasantestUser } from './user.js';
 export { type WaitForOptions } from './pptr-testing-library.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,31 @@
+import { Console } from 'node:console';
+import { dirname, isAbsolute, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import _ansiRegex from 'ansi-regex';
+import { parseStackTrace } from 'errorstacks';
+import { bgRed, bold, options as koloristOpts, red, white } from 'kolorist';
 import * as puppeteer from 'puppeteer';
-import { relative, join, isAbsolute, dirname } from 'path';
-import type { BoundQueries, WaitForOptions } from './pptr-testing-library';
+
+import { ansiColorsLog } from './ansi-colors-browser.js';
+import type { AsyncHookTracker } from './async-hooks.js';
+import { createAsyncHookTracker } from './async-hooks.js';
+import { connectToBrowser } from './connect-to-browser.js';
+import type { ModuleServerOpts } from './module-server';
+import { createModuleServer } from './module-server';
+import { createBuildStatusTracker } from './module-server/build-status-tracker.js';
+import { cleanupClientRuntimeServer } from './module-server/client-runtime-server.js';
+import type { BoundQueries, WaitForOptions } from './pptr-testing-library.js';
 import {
   getQueriesForElement,
   waitFor as innerWaitFor,
-} from './pptr-testing-library';
-import { connectToBrowser } from './connect-to-browser';
-import { parseStackTrace } from 'errorstacks';
-import './extend-expect';
-import { bgRed, white, options as koloristOpts, bold, red } from 'kolorist';
-import { ansiColorsLog } from './ansi-colors-browser';
-import _ansiRegex from 'ansi-regex';
-import { fileURLToPath } from 'url';
-import type { PleasantestUser, UserOpts } from './user';
-import { pleasantestUser } from './user';
-import { assertElementHandle } from './utils';
-import type { ModuleServerOpts } from './module-server';
-import { createModuleServer } from './module-server';
-import { cleanupClientRuntimeServer } from './module-server/client-runtime-server';
-import { Console } from 'console';
-import { createBuildStatusTracker } from './module-server/build-status-tracker';
-import { sourceMapErrorFromBrowser } from './source-map-error-from-browser';
-import type { AsyncHookTracker } from './async-hooks';
-import { createAsyncHookTracker } from './async-hooks';
+} from './pptr-testing-library.js';
+import { sourceMapErrorFromBrowser } from './source-map-error-from-browser.js';
+import type { PleasantestUser, UserOpts } from './user.js';
+import { pleasantestUser } from './user.js';
+import { assertElementHandle } from './utils.js';
+
+import './extend-expect.js';
 
 export { JSHandle, ElementHandle } from 'puppeteer';
 koloristOpts.enabled = true;
@@ -492,5 +495,5 @@ export {
   accessibilityTreeSnapshotSerializer,
 } from './accessibility';
 
-export { type PleasantestUser } from './user';
-export { type WaitForOptions } from './pptr-testing-library';
+export { type PleasantestUser } from './user.js';
+export { type WaitForOptions } from './pptr-testing-library.js';

--- a/src/jest-dom/index.ts
+++ b/src/jest-dom/index.ts
@@ -1,11 +1,11 @@
-import { addToElementCache, serialize } from '../serialize';
+import { addToElementCache, serialize } from '../serialize/index.js';
 // @ts-expect-error types are not provided for this sub-path import
 export * from '@testing-library/jest-dom/matchers';
 export {
   reviveElementsInString,
   printElement,
   deserialize,
-} from '../serialize';
+} from '../serialize/index.js';
 
 const runUtilInNode = (name: string, args: any[]) => {
   // If there are nested calls to $JEST_UTILS$

--- a/src/jest-dom/rollup.config.js
+++ b/src/jest-dom/rollup.config.js
@@ -1,6 +1,7 @@
 import babel from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
+
 import { rollupPluginDomAccessibilityApi } from '../rollup-plugin-dom-accessibility-api.js';
 
 const extensions = ['.js', '.jsx', '.es6', '.es', '.mjs', '.ts', '.tsx'];

--- a/src/module-server/bundle-npm-module.ts
+++ b/src/module-server/bundle-npm-module.ts
@@ -1,12 +1,15 @@
+import { promises as fs } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import commonjs from '@rollup/plugin-commonjs';
+import { parse } from 'cjs-module-lexer';
+import * as esbuild from 'esbuild';
 import type { Plugin, RollupCache } from 'rollup';
 import { rollup } from 'rollup';
-import { promises as fs } from 'fs';
-import commonjs from '@rollup/plugin-commonjs';
-import { environmentVariablesPlugin } from './plugins/environment-variables-plugin';
-import * as esbuild from 'esbuild';
-import { parse } from 'cjs-module-lexer';
-import { createRequire } from 'module';
-import { isBareImport } from './extensions-and-detection';
+
+import { isBareImport } from './extensions-and-detection.js';
+import { environmentVariablesPlugin } from './plugins/environment-variables-plugin.js';
+
 let npmCache: RollupCache | undefined;
 
 /**

--- a/src/module-server/client-runtime-server.ts
+++ b/src/module-server/client-runtime-server.ts
@@ -1,8 +1,10 @@
-import path from 'path';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import type { Middleware, Polka } from 'polka';
-import { fileURLToPath } from 'url';
-import { createServer } from './server';
-import { promises as fs } from 'fs';
+
+import { createServer } from './server.js';
 
 let currentDir: string;
 try {

--- a/src/module-server/error-with-location.ts
+++ b/src/module-server/error-with-location.ts
@@ -1,6 +1,7 @@
+import { promises as fs } from 'node:fs';
+
 import * as colors from 'kolorist';
 import { createCodeFrame } from 'simple-code-frame';
-import { promises as fs } from 'fs';
 
 export class ErrorWithLocation extends Error {
   filename?: string;

--- a/src/module-server/index.ts
+++ b/src/module-server/index.ts
@@ -1,17 +1,18 @@
+import type * as esbuild from 'esbuild';
 import type polka from 'polka';
 import type { SourceDescription } from 'rollup';
-import type { Plugin } from './plugin';
-import { indexHTMLMiddleware } from './middleware/index-html';
-import { jsMiddleware } from './middleware/js';
-import { npmPlugin } from './plugins/npm-plugin';
-import { environmentVariablesPlugin } from './plugins/environment-variables-plugin';
-import { resolveExtensionsPlugin } from './plugins/resolve-extensions-plugin';
-import { createServer } from './server';
-import { esbuildPlugin } from './plugins/esbuild-plugin';
-import { cssPlugin } from './plugins/css';
-import { cssMiddleware } from './middleware/css';
-import { staticMiddleware } from './middleware/static';
-import type * as esbuild from 'esbuild';
+
+import { cssMiddleware } from './middleware/css.js';
+import { indexHTMLMiddleware } from './middleware/index-html.js';
+import { jsMiddleware } from './middleware/js.js';
+import { staticMiddleware } from './middleware/static.js';
+import type { Plugin } from './plugin.js';
+import { cssPlugin } from './plugins/css.js';
+import { environmentVariablesPlugin } from './plugins/environment-variables-plugin.js';
+import { esbuildPlugin } from './plugins/esbuild-plugin.js';
+import { npmPlugin } from './plugins/npm-plugin.js';
+import { resolveExtensionsPlugin } from './plugins/resolve-extensions-plugin.js';
+import { createServer } from './server.js';
 
 export interface ModuleServerOpts {
   root?: string;

--- a/src/module-server/middleware/css.ts
+++ b/src/module-server/middleware/css.ts
@@ -1,9 +1,11 @@
-import { posix, relative, resolve, sep } from 'path';
+import { promises as fs } from 'node:fs';
+import { posix, relative, resolve, sep } from 'node:path';
+
 import type polka from 'polka';
-import { promises as fs } from 'fs';
-import { cssPlugin } from '../plugins/css';
 import type { PluginContext, TransformPluginContext } from 'rollup';
-import { cssExts } from '../extensions-and-detection';
+
+import { cssExts } from '../extensions-and-detection.js';
+import { cssPlugin } from '../plugins/css.js';
 
 interface CSSMiddlewareOpts {
   root: string;

--- a/src/module-server/middleware/js.ts
+++ b/src/module-server/middleware/js.ts
@@ -1,19 +1,21 @@
-import { dirname, posix, relative, resolve, sep } from 'path';
+import { promises as fs } from 'node:fs';
+import { dirname, posix, relative, resolve, sep } from 'node:path';
+
+import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping';
+import MagicString from 'magic-string';
 import type polka from 'polka';
 import type {
   PartialResolvedId,
   ResolveIdResult,
   SourceDescription,
 } from 'rollup';
-import type { Plugin } from '../plugin';
-import { createPluginContainer } from '../rollup-plugin-container';
-import { promises as fs } from 'fs';
-import { transformImports } from '../transform-imports';
-import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping';
-import MagicString from 'magic-string';
-import { jsExts } from '../extensions-and-detection';
-import { rejectBuild } from '../build-status-tracker';
-import { ErrorWithLocation } from '../error-with-location';
+
+import { rejectBuild } from '../build-status-tracker.js';
+import { ErrorWithLocation } from '../error-with-location.js';
+import { jsExts } from '../extensions-and-detection.js';
+import type { Plugin } from '../plugin.js';
+import { createPluginContainer } from '../rollup-plugin-container.js';
+import { transformImports } from '../transform-imports.js';
 
 interface JSMiddlewareOpts {
   root: string;

--- a/src/module-server/middleware/static.ts
+++ b/src/module-server/middleware/static.ts
@@ -1,7 +1,8 @@
-import { posix, resolve } from 'path';
-import type polka from 'polka';
-import { promises as fs, createReadStream } from 'fs';
+import { createReadStream, promises as fs } from 'node:fs';
+import { posix, resolve } from 'node:path';
+
 import mime from 'mime/lite';
+import type polka from 'polka';
 
 interface StaticMiddlewareOpts {
   root: string;

--- a/src/module-server/node-resolve.test.ts
+++ b/src/module-server/node-resolve.test.ts
@@ -1,8 +1,10 @@
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import { dirname, join, normalize, posix, sep } from 'path';
-import { changeErrorMessage } from '../utils';
-import { nodeResolve } from './node-resolve';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, normalize, posix, sep } from 'node:path';
+
+import { changeErrorMessage } from '../utils.js';
+
+import { nodeResolve } from './node-resolve.js';
 
 const createdPaths: string[] = [];
 

--- a/src/module-server/node-resolve.ts
+++ b/src/module-server/node-resolve.ts
@@ -1,10 +1,12 @@
-import { dirname, join, posix, relative, resolve as pResolve } from 'path';
-import { promises as fs } from 'fs';
+import { promises as fs } from 'node:fs';
+import { dirname, join, resolve as pResolve, posix, relative } from 'node:path';
+
 import { resolve, legacy as resolveLegacy } from 'resolve.exports';
+
 import {
   isBareImport,
   isRelativeOrAbsoluteImport,
-} from './extensions-and-detection';
+} from './extensions-and-detection.js';
 
 // Only used for node_modules
 const resolveCache = new Map<string, ResolveResult>();

--- a/src/module-server/plugins/css.ts
+++ b/src/module-server/plugins/css.ts
@@ -1,7 +1,9 @@
+import { posix, relative, resolve, sep } from 'node:path';
+
 import postcssPlugin from 'rollup-plugin-postcss';
-import { transformCssImports } from '../transform-css-imports';
-import { posix, relative, resolve, sep } from 'path';
-import { cssExts } from '../extensions-and-detection';
+
+import { cssExts } from '../extensions-and-detection.js';
+import { transformCssImports } from '../transform-css-imports.js';
 
 export const cssPlugin = ({
   returnCSS = false,

--- a/src/module-server/plugins/environment-variables-plugin.ts
+++ b/src/module-server/plugins/environment-variables-plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../plugin';
+import type { Plugin } from '../plugin.js';
 
 /**
  * Passes environment variables to pass into the bundle.  They can be accessed via import.meta.env.<name> (or process.env.<name> for compatability)

--- a/src/module-server/plugins/esbuild-plugin.ts
+++ b/src/module-server/plugins/esbuild-plugin.ts
@@ -1,7 +1,9 @@
+import { extname } from 'node:path';
+
 import * as esbuild from 'esbuild';
-import { extname } from 'path';
-import type { Plugin } from '../plugin';
-import { jsExts } from '../extensions-and-detection';
+
+import { jsExts } from '../extensions-and-detection.js';
+import type { Plugin } from '../plugin.js';
 
 const shouldProcess = (id: string) => {
   if (id[0] === '\0') return false;

--- a/src/module-server/plugins/npm-plugin.ts
+++ b/src/module-server/plugins/npm-plugin.ts
@@ -1,12 +1,17 @@
-import { dirname, join } from 'path';
-import type { Plugin } from '../plugin';
-import { promises as fs } from 'fs';
-import { fileURLToPath } from 'url';
-import { jsExts, isBareImport, npmPrefix } from '../extensions-and-detection';
-import { changeErrorMessage } from '../../utils';
-import { bundleNpmModule } from '../bundle-npm-module';
-import { resolveFromNodeModules } from '../node-resolve';
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { changeErrorMessage } from '../../utils.js';
+import { bundleNpmModule } from '../bundle-npm-module.js';
+import {
+  isBareImport,
+  jsExts,
+  npmPrefix,
+} from '../extensions-and-detection.js';
+import { resolveFromNodeModules } from '../node-resolve.js';
+import type { Plugin } from '../plugin.js';
 
 // This is the folder that Pleasantest is installed in (e.g. <something>/node_modules/pleasantest)
 const installFolder = dirname(dirname(dirname(fileURLToPath(import.meta.url))));

--- a/src/module-server/plugins/resolve-extensions-plugin.ts
+++ b/src/module-server/plugins/resolve-extensions-plugin.ts
@@ -1,7 +1,7 @@
-import type { Plugin } from '../plugin';
-import { isRelativeOrAbsoluteImport } from '../extensions-and-detection';
-import { resolveRelativeOrAbsolute } from '../node-resolve';
-import { changeErrorMessage } from '../../utils';
+import { changeErrorMessage } from '../../utils.js';
+import { isRelativeOrAbsoluteImport } from '../extensions-and-detection.js';
+import { resolveRelativeOrAbsolute } from '../node-resolve.js';
+import type { Plugin } from '../plugin.js';
 
 /**
  * Handles resolving './foo' to './foo.js', and './foo/index.js', and resolving through './foo/package.json'

--- a/src/module-server/rollup-plugin-container.ts
+++ b/src/module-server/rollup-plugin-container.ts
@@ -39,17 +39,19 @@
   - Stubbed out options hook was added
   */
 
-import { resolve, dirname } from 'path';
+import { dirname, resolve } from 'node:path';
+
+import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping';
 import { Parser } from 'acorn';
 import type {
   LoadResult,
-  PluginContext as RollupPluginContext,
   ResolveIdResult,
+  PluginContext as RollupPluginContext,
 } from 'rollup';
-import type { Plugin } from './plugin';
-import { combineSourceMaps } from './combine-source-maps';
-import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping';
-import { ErrorWithLocation } from './error-with-location';
+
+import { combineSourceMaps } from './combine-source-maps.js';
+import { ErrorWithLocation } from './error-with-location.js';
+import type { Plugin } from './plugin.js';
 
 /** Fast splice(x,1) when order doesn't matter (h/t Rich) */
 const popIndex = (array: any[], index: number) => {

--- a/src/module-server/server.ts
+++ b/src/module-server/server.ts
@@ -1,5 +1,6 @@
-import { Console } from 'console';
-import type { AddressInfo, Socket } from 'net';
+import { Console } from 'node:console';
+import type { AddressInfo, Socket } from 'node:net';
+
 import type { Polka } from 'polka';
 import polka from 'polka';
 

--- a/src/module-server/transform-imports.ts
+++ b/src/module-server/transform-imports.ts
@@ -30,11 +30,13 @@
   - Parsing errors are thrown with code frame
   */
 
-import { parse } from 'es-module-lexer';
-import { ErrorWithLocation } from './error-with-location';
+import { extname } from 'node:path';
+
 import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping';
-import { extname } from 'path';
-import { jsExts } from './extensions-and-detection';
+import { parse } from 'es-module-lexer';
+
+import { ErrorWithLocation } from './error-with-location.js';
+import { jsExts } from './extensions-and-detection.js';
 
 type MaybePromise<T> = Promise<T> | T;
 type ResolveFn = (

--- a/src/pptr-testing-library-client/index.ts
+++ b/src/pptr-testing-library-client/index.ts
@@ -1,5 +1,6 @@
 // @ts-expect-error types are not defined for this internal import
 import { configure } from '@testing-library/dom/dist/config';
+
 import { addToElementCache } from '../serialize';
 // @ts-expect-error types are not defined for this internal import
 export * from '@testing-library/dom/dist/queries';

--- a/src/pptr-testing-library-client/index.ts
+++ b/src/pptr-testing-library-client/index.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error types are not defined for this internal import
 import { configure } from '@testing-library/dom/dist/config';
 
-import { addToElementCache } from '../serialize';
+import { addToElementCache } from '../serialize/index.js';
 // @ts-expect-error types are not defined for this internal import
 export * from '@testing-library/dom/dist/queries';
 // @ts-expect-error types are not defined for this internal import
@@ -11,7 +11,7 @@ export {
   reviveElementsInString,
   printElement,
   addToElementCache,
-} from '../serialize';
+} from '../serialize/index.js';
 
 (configure as typeof import('@testing-library/dom').configure)({
   getElementError(message, container) {

--- a/src/pptr-testing-library-client/rollup.config.js
+++ b/src/pptr-testing-library-client/rollup.config.js
@@ -1,7 +1,9 @@
+import * as path from 'node:path';
+
 import babel from '@rollup/plugin-babel';
-import * as path from 'path';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
+
 import { rollupPluginAriaQuery } from '../rollup-plugin-aria-query.js';
 import { rollupPluginDomAccessibilityApi } from '../rollup-plugin-dom-accessibility-api.js';
 

--- a/src/pptr-testing-library.ts
+++ b/src/pptr-testing-library.ts
@@ -1,12 +1,13 @@
 import type { queries } from '@testing-library/dom';
+import type { ElementHandle, JSHandle, Page } from 'puppeteer';
+
+import type { AsyncHookTracker } from './async-hooks.js';
+import { createClientRuntimeServer } from './module-server/client-runtime-server.js';
 import {
   jsHandleToArray,
   printColorsInErrorMessages,
   removeFuncFromStackTrace,
-} from './utils';
-import type { ElementHandle, JSHandle, Page } from 'puppeteer';
-import { createClientRuntimeServer } from './module-server/client-runtime-server';
-import type { AsyncHookTracker } from './async-hooks';
+} from './utils.js';
 
 type ElementToElementHandle<Input> = Input extends Element
   ? ElementHandle<Input>

--- a/src/serialize/index.test.ts
+++ b/src/serialize/index.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  * @jest-environment-options {"customExportConditions": ["require"]}
  */
-import { deserialize, printElement, serialize } from '.';
+import { deserialize, printElement, serialize } from './index.js';
 
 test('objects', () => {
   const input = { 1234: { abcd: 'abc' } };

--- a/src/serialize/index.test.ts
+++ b/src/serialize/index.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  * @jest-environment-options {"customExportConditions": ["require"]}
  */
-import { printElement, deserialize, serialize } from '.';
+import { deserialize, printElement, serialize } from '.';
 
 test('objects', () => {
   const input = { 1234: { abcd: 'abc' } };

--- a/src/source-map-error-from-browser.ts
+++ b/src/source-map-error-from-browser.ts
@@ -1,8 +1,10 @@
-import { join, posix, sep, resolve } from 'path';
-import { parseStackTrace } from 'errorstacks';
+import { join, posix, resolve, sep } from 'node:path';
+
 import _ansiRegex from 'ansi-regex';
-import { printStackLine, removeFuncFromStackTrace } from './utils';
+import { parseStackTrace } from 'errorstacks';
 import type { SourceDescription } from 'rollup';
+
+import { printStackLine, removeFuncFromStackTrace } from './utils.js';
 
 export const sourceMapErrorFromBrowser = async (
   res: unknown,

--- a/src/start-disowned-browser.ts
+++ b/src/start-disowned-browser.ts
@@ -1,6 +1,7 @@
-import os from 'os';
-import path from 'path';
-import { promises as fs } from 'fs';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import * as puppeteer from 'puppeteer';
 
 process.on('message', async ({ browser, headless }) => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,50 @@
+// These dependencies have type declarations that aren't compatable with TS moduleResolution: node16
+// The -original-types fake dependencies are defined in tsconfig.json
+
+declare module 'svelte-preprocess' {
+  export * from 'svelte-preprocess-original-types';
+  import * as mod from 'svelte-preprocess-original-types';
+  export default mod.default;
+}
+
+declare module 'rollup-plugin-vue' {
+  export * from 'rollup-plugin-vue-original-types';
+  import mod from 'rollup-plugin-vue-original-types';
+  export default mod.default;
+}
+
+declare module 'rollup-plugin-svelte' {
+  export * from 'rollup-plugin-svelte-original-types';
+  import mod from 'rollup-plugin-svelte-original-types';
+  export default mod.default;
+}
+
+declare module '@rollup/plugin-alias' {
+  export * from 'rollup-plugin-alias-original-types';
+  import mod from 'rollup-plugin-alias-original-types';
+  export default mod.default;
+}
+
+declare module 'rollup-plugin-postcss' {
+  export * from 'rollup-plugin-postcss-original-types';
+  import mod from 'rollup-plugin-postcss-original-types';
+  export default mod.default;
+}
+
+declare module 'magic-string' {
+  export * from 'magic-string-original-types';
+  import mod from 'magic-string-original-types';
+  export default mod.default;
+}
+
+declare module '@ampproject/remapping' {
+  export * from 'amp-remapping-original-types';
+  import mod from 'amp-remapping-original-types';
+  export default mod.default;
+}
+
+declare module '@rollup/plugin-commonjs' {
+  export * from 'rollup-commonjs-original-types';
+  import mod from 'rollup-commonjs-original-types';
+  export default mod.default;
+}

--- a/src/user-util/index.ts
+++ b/src/user-util/index.ts
@@ -1,4 +1,4 @@
-export { printElement } from '../serialize';
+export { printElement } from '../serialize/index.js';
 
 export const assertAttached = (el: Element) => {
   if (!el.isConnected) {

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,12 +1,13 @@
 import type { ElementHandle, JSHandle, Page } from 'puppeteer';
-import type { AsyncHookTracker } from './async-hooks';
-import { createClientRuntimeServer } from './module-server/client-runtime-server';
+
+import type { AsyncHookTracker } from './async-hooks.js';
+import { createClientRuntimeServer } from './module-server/client-runtime-server.js';
 import {
   assertElementHandle,
   jsHandleToArray,
   printColorsInErrorMessages,
   removeFuncFromStackTrace,
-} from './utils';
+} from './utils.js';
 
 export interface PleasantestUser {
   /** Clicks an element, if the element is visible and not covered by another element */

--- a/src/user.ts
+++ b/src/user.ts
@@ -70,7 +70,10 @@ export const pleasantestUser = async (
 ) => {
   const { port } = await createClientRuntimeServer();
   const runWithUtils = <Args extends any[], Return>(
-    fn: (userUtil: typeof import('./user-util'), ...args: Args) => Return,
+    fn: (
+      userUtil: typeof import('./user-util/index.js'),
+      ...args: Args
+    ) => Return,
   ): ((...args: Args) => Promise<Return>) =>
     new Function(
       '...args',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import type { ElementHandle, JSHandle } from 'puppeteer';
 import * as kolorist from 'kolorist';
+import type { ElementHandle, JSHandle } from 'puppeteer';
 
 export const jsHandleToArray = async (arrayHandle: JSHandle) => {
   const properties = await arrayHandle.getProperties();

--- a/tests/forgot-await.test.ts
+++ b/tests/forgot-await.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @cloudfour/typescript-eslint/require-await */
-import { withBrowser, getAccessibilityTree } from 'pleasantest';
-import { printErrorFrames } from './test-utils';
+import { getAccessibilityTree, withBrowser } from 'pleasantest';
+
+import { printErrorFrames } from './test-utils.js';
 
 test('forgot await detection works even if other async stuff happens afterwards', async () => {
   const error = await withBrowser(async ({ screen, utils, user }) => {

--- a/tests/test-utils.test.ts
+++ b/tests/test-utils.test.ts
@@ -1,4 +1,4 @@
-import { printErrorFrames } from './test-utils';
+import { printErrorFrames } from './test-utils.js';
 
 test('printErrorFrames with native stack trace', async () => {
   const error = await fnThatThrows().catch((error) => error);

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,7 +1,8 @@
-import { parseStackTrace } from 'errorstacks';
-import { promises as fs } from 'fs';
-import * as path from 'path';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
 import ansiRegex from 'ansi-regex';
+import { parseStackTrace } from 'errorstacks';
 
 export const printErrorFrames = async (error?: Error) => {
   if (!error?.stack) return '';

--- a/tests/testing-library-queries/variants-of-queries.test.ts
+++ b/tests/testing-library-queries/variants-of-queries.test.ts
@@ -1,6 +1,7 @@
 import type { ElementHandle } from 'pleasantest';
 import { withBrowser } from 'pleasantest';
-import { printErrorFrames } from '../test-utils';
+
+import { printErrorFrames } from '../test-utils.js';
 
 const singleElementMarkup = `
   <h1>Hello</h1>

--- a/tests/user/actionability.test.ts
+++ b/tests/user/actionability.test.ts
@@ -1,11 +1,13 @@
-import type { ElementHandle } from 'puppeteer';
+import path from 'node:path';
+
 import { withBrowser } from 'pleasantest';
+import type { ElementHandle } from 'puppeteer';
+
 import {
   cleanupClientRuntimeServer,
   createClientRuntimeServer,
-} from '../../src/module-server/client-runtime-server';
-import path from 'path';
-import { printColorsInErrorMessages } from '../../src/utils';
+} from '../../src/module-server/client-runtime-server.js';
+import { printColorsInErrorMessages } from '../../src/utils.js';
 
 const runWithUtils = async <Args extends any[], Return>(
   fn: (userUtil: typeof import('../../src/user-util'), ...args: Args) => Return,

--- a/tests/user/actionability.test.ts
+++ b/tests/user/actionability.test.ts
@@ -10,7 +10,10 @@ import {
 import { printColorsInErrorMessages } from '../../src/utils.js';
 
 const runWithUtils = async <Args extends any[], Return>(
-  fn: (userUtil: typeof import('../../src/user-util'), ...args: Args) => Return,
+  fn: (
+    userUtil: typeof import('../../src/user-util/index.js'),
+    ...args: Args
+  ) => Return,
 ): Promise<(...args: Args) => Promise<Return>> => {
   const { port } = await createClientRuntimeServer(
     path.join(process.cwd(), 'dist'),

--- a/tests/user/click.test.ts
+++ b/tests/user/click.test.ts
@@ -1,6 +1,6 @@
-import type * as puppeteeer from 'puppeteer';
 import { withBrowser } from 'pleasantest';
 import type { PleasantestUtils } from 'pleasantest';
+import type * as puppeteeer from 'puppeteer';
 
 const setupOverlappingElements = async (
   utils: PleasantestUtils,

--- a/tests/user/general.test.ts
+++ b/tests/user/general.test.ts
@@ -1,5 +1,6 @@
 import { withBrowser } from 'pleasantest';
-import { printErrorFrames } from '../test-utils';
+
+import { printErrorFrames } from '../test-utils.js';
 
 test(
   'Stack frames are correct',

--- a/tests/utils/external-throwing.ts
+++ b/tests/utils/external-throwing.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error intentionally unused
 let foo: string;
 
 throw new Error('asdf');

--- a/tests/utils/external-with-side-effect.ts
+++ b/tests/utils/external-with-side-effect.ts
@@ -1,5 +1,7 @@
-interface Window {
-  foo: string;
+declare global {
+  interface Window {
+    foo: string;
+  }
 }
 
 window.foo = 'hi';

--- a/tests/utils/loadCSS.test.ts
+++ b/tests/utils/loadCSS.test.ts
@@ -1,4 +1,5 @@
-import * as path from 'path';
+import * as path from 'node:path';
+
 import { withBrowser } from 'pleasantest';
 
 test(

--- a/tests/utils/loadJS.test.ts
+++ b/tests/utils/loadJS.test.ts
@@ -1,5 +1,6 @@
 import { withBrowser } from 'pleasantest';
-import { formatErrorWithCodeFrame, printErrorFrames } from '../test-utils';
+
+import { formatErrorWithCodeFrame, printErrorFrames } from '../test-utils.js';
 
 test(
   'loads and executes .ts file with transpiling',

--- a/tests/utils/runJS.test.tsx
+++ b/tests/utils/runJS.test.tsx
@@ -1,12 +1,12 @@
 import aliasPlugin from '@rollup/plugin-alias';
-import babel from '@rollup/plugin-babel';
+import { babel } from '@rollup/plugin-babel';
 import { withBrowser } from 'pleasantest';
 import type { PleasantestContext, PleasantestUtils } from 'pleasantest';
 import sveltePlugin from 'rollup-plugin-svelte';
 import vuePlugin from 'rollup-plugin-vue';
 import sveltePreprocess from 'svelte-preprocess';
 
-import { formatErrorWithCodeFrame, printErrorFrames } from '../test-utils.ts';
+import { formatErrorWithCodeFrame, printErrorFrames } from '../test-utils.js';
 
 const createHeading = async ({
   utils,
@@ -443,7 +443,14 @@ describe('Ecosystem interoperability', () => {
     withBrowser(
       {
         moduleServer: {
-          plugins: [sveltePlugin({ preprocess: sveltePreprocess() })],
+          plugins: [
+            sveltePlugin({
+              preprocess: sveltePreprocess({
+                // Does not work with module set to nodenext, works with either commonjs or esnext
+                typescript: { compilerOptions: { module: 'commonjs' } },
+              }),
+            }),
+          ],
         },
       },
       async ({ utils, screen, user }) => {

--- a/tests/utils/runJS.test.tsx
+++ b/tests/utils/runJS.test.tsx
@@ -1,11 +1,12 @@
-import { withBrowser } from 'pleasantest';
-import type { PleasantestContext, PleasantestUtils } from 'pleasantest';
-import { formatErrorWithCodeFrame, printErrorFrames } from '../test-utils';
-import vuePlugin from 'rollup-plugin-vue';
-import sveltePlugin from 'rollup-plugin-svelte';
-import sveltePreprocess from 'svelte-preprocess';
 import aliasPlugin from '@rollup/plugin-alias';
 import babel from '@rollup/plugin-babel';
+import { withBrowser } from 'pleasantest';
+import type { PleasantestContext, PleasantestUtils } from 'pleasantest';
+import sveltePlugin from 'rollup-plugin-svelte';
+import vuePlugin from 'rollup-plugin-vue';
+import sveltePreprocess from 'svelte-preprocess';
+
+import { formatErrorWithCodeFrame, printErrorFrames } from '../test-utils.ts';
 
 const createHeading = async ({
   utils,

--- a/tests/wait-for.test.ts
+++ b/tests/wait-for.test.ts
@@ -1,5 +1,6 @@
 import { withBrowser } from 'pleasantest';
-import { printErrorFrames } from './test-utils';
+
+import { printErrorFrames } from './test-utils.js';
 
 test(
   'Basic case',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,18 +4,56 @@
     "strictBindCallApply": true,
     "noEmit": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "paths": {
-      "pleasantest": ["./src"],
-      "puppeteer": ["./node_modules/@types/puppeteer"]
+      // Self-reference to the src types, so that running `npm run type` does not depend on dist/index.d.ts existing
+      "pleasantest": ["./src/index.ts"],
+
+      // These dependencies have export maps but don't have their types defined inside the export maps
+      "puppeteer": ["./node_modules/@types/puppeteer/index.d.ts"],
+      "errorstacks": ["./node_modules/errorstacks/dist/types/index.d.ts"],
+      "dom-accessibility-api": [
+        "./node_modules/dom-accessibility-api/dist/index.d.ts"
+      ],
+      "es-module-lexer": ["./node_modules/es-module-lexer/types/lexer.d.ts"],
+      "simple-code-frame": [
+        "./node_modules/simple-code-frame/dist/types/index.d.ts"
+      ],
+      "kolorist": ["./node_modules/kolorist/dist/types/index.d.ts"],
+      "resolve.exports": ["./node_modules/resolve.exports/index.d.ts"],
+      "mime/lite": ["./node_modules/@types/mime/lite.d.ts"],
+
+      // These dependencies have type declarations that aren't compatable with TS moduleResolution: node16
+      // These are used in src/types.d.ts
+      "rollup-plugin-commonjs-original-types": [
+        "./node_modules/@rollup/plugin-commonjs/types/index.d.ts"
+      ],
+      "svelte-preprocess-original-types": [
+        "./node_modules/svelte-preprocess/dist/index.d.ts"
+      ],
+      "rollup-plugin-vue-original-types": [
+        "./node_modules/rollup-plugin-vue/dist/index.d.ts"
+      ],
+      "rollup-plugin-svelte-original-types": [
+        "./node_modules/rollup-plugin-svelte/index.d.ts"
+      ],
+      "rollup-plugin-alias-original-types": [
+        "./node_modules/@rollup/plugin-alias/types/index.d.ts"
+      ],
+      "rollup-plugin-postcss-original-types": [
+        "./node_modules/rollup-plugin-postcss/types/index.d.ts"
+      ],
+      "magic-string-original-types": ["./node_modules/magic-string/index.d.ts"],
+      "amp-remapping-original-types": [
+        "./node_modules/@ampproject/remapping/dist/types/remapping.d.ts"
+      ]
     },
     "useUnknownInCatchVariables": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "importsNotUsedAsValues": "error",
-    "target": "ES2019",
+    "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["jest"],
     "allowJs": true,


### PR DESCRIPTION
This comes along with the eslint plugin update: all the imports are sorted and grouped, node internal imports are prefixed with `node:`, and all imports are changed to use `.js` extensions instead of omitting extensions.

I enabled the TS settings to follow Node's ESM resolution. Many npm packages don't yet correctly support this so I had to create a `types.d.ts` file to adjust some of their types, and override some of the types resolutions in `tsconfig.json`.

It is easiest to review the commits separately; the 2nd commit is all automated changes so it doesn't need careful review.