### PR TITLE
Don't reset `<head>` when using `injectHTML`

### DIFF
--- a/.changeset/empty-cooks-roll.md
+++ b/.changeset/empty-cooks-roll.md
@@ -1,0 +1,7 @@
+---
+'pleasantest': patch
+---
+
+[bugfix] Don't override `<head>` when using `utils.injectHTML`
+
+This was a bug introduced in `3.0.0`. This change fixes that behavior to match what is documented. The documented behavior is that `injectHTML` replaces the content of the body _only_. The behavior introduced in `3.0.0` also resets the `<head>` to the default; that was unintended behavior that is now removed.

--- a/tests/utils/injectHTML.test.ts
+++ b/tests/utils/injectHTML.test.ts
@@ -3,14 +3,31 @@ import { withBrowser } from 'pleasantest';
 test(
   'injectHTML',
   withBrowser(async ({ utils, page }) => {
-    const getHTML = () => page.evaluate(() => document.body.innerHTML.trim());
+    const getHTML = () =>
+      page.evaluate(() => document.documentElement.innerHTML.trim());
 
     await utils.injectHTML('<div>Hi</div>');
-    expect(await getHTML()).toEqual('<div>Hi</div>');
+    expect(await getHTML()).toMatchInlineSnapshot(`
+      "<head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <link rel="icon" href="data:;base64,=">
+          <title>pleasantest</title>
+        </head>
+        <body><div>Hi</div></body>"
+    `);
 
     // It should fully override existing content
     await utils.injectHTML('<div>Hiya</div>');
-    expect(await getHTML()).toEqual('<div>Hiya</div>');
+    expect(await getHTML()).toMatchInlineSnapshot(`
+      "<head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <link rel="icon" href="data:;base64,=">
+          <title>pleasantest</title>
+        </head>
+        <body><div>Hiya</div></body>"
+    `);
 
     // Executes scripts by default
     await utils.injectHTML(`
@@ -18,21 +35,76 @@ test(
       <script>document.querySelector('div').textContent = 'changed'</script>
     `);
     expect(await getHTML()).toMatchInlineSnapshot(`
-      "<div>changed</div>
-            <script>document.querySelector('div').textContent = 'changed'</script>"
+      "<head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <link rel="icon" href="data:;base64,=">
+          <title>pleasantest</title>
+        </head>
+        <body>
+            <div>changed</div>
+            <script>document.querySelector('div').textContent = 'changed'</script>
+          </body>"
     `);
 
     // Can pass option to not execute
     await utils.injectHTML(
       `
       <div>hello</div>
-      <script>document.querySelector('div').textContent = 'changed'</script>
+      <script foo="bar" asdf>document.querySelector('div').textContent = 'changed'</script>
     `,
       { executeScriptTags: false },
     );
     expect(await getHTML()).toMatchInlineSnapshot(`
-      "<div>hello</div>
-            <script>document.querySelector('div').textContent = 'changed'</script>"
+      "<head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <link rel="icon" href="data:;base64,=">
+          <title>pleasantest</title>
+        </head>
+        <body>
+            <div>hello</div>
+            <script foo="bar" asdf="">document.querySelector('div').textContent = 'changed'</script>
+          </body>"
+    `);
+
+    // Stuff in <head> should be left as-is and not re-executed after injectHTML is called again below
+    await page.evaluate(() => {
+      const script = document.createElement('script');
+      script.text =
+        'document.body.querySelector("div").innerHTML = "changed from script in head"';
+      document.head.append(script);
+    });
+
+    expect(await getHTML()).toMatchInlineSnapshot(`
+      "<head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <link rel="icon" href="data:;base64,=">
+          <title>pleasantest</title>
+        <script>document.body.querySelector("div").innerHTML = "changed from script in head"</script></head>
+        <body>
+            <div>changed from script in head</div>
+            <script foo="bar" asdf="">document.querySelector('div').textContent = 'changed'</script>
+          </body>"
+    `);
+
+    await utils.injectHTML(
+      `
+      <div>injected HTML</div>
+    `,
+    );
+
+    expect(await getHTML()).toMatchInlineSnapshot(`
+      "<head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <link rel="icon" href="data:;base64,=">
+          <title>pleasantest</title>
+        <script>document.body.querySelector("div").innerHTML = "changed from script in head"</script></head>
+        <body>
+            <div>injected HTML</div>
+          </body>"
     `);
   }),
 );


### PR DESCRIPTION
I noticed this bug while trying to update `@cloudfour/patterns`. This is a bug introduced in 3.0.0 when I switched the default implementation of `injectHTML` to use `document.write` instead of `document.body.innerHTML = ...`.

When calling `injectHTML`, scripts/stylesheets and other changes to `head` would get reset back to the default/initial contents of `head` instead of being left alone.

The documented behavior of `injectHTML` is "Set the contents of `document.body`." (and I think this makes sense). This PR removes the accidental additional behavior of resetting `<head>`.

Most of this PR is updating the tests to also snapshot the `<head>`, as well as one new test for an edge case to make sure that `<head>` is not modified or re-evaluated when `injectHTML` is called.