### PR TITLE
Generate .d.cts and .d.mts files

### DIFF
--- a/.changeset/rotten-ads-do.md
+++ b/.changeset/rotten-ads-do.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': patch
+---
+
+Fix types in export map

--- a/package.json
+++ b/package.json
@@ -118,9 +118,14 @@
   },
   "main": "./dist/cjs/index.cjs",
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "types": "./dist/index.d.ts"
+    "require": {
+      ".": "./dist/cjs/index.cjs",
+      "types": "./dist/index.d.cts"
+    },
+    "import": {
+      ".": "./dist/esm/index.mjs",
+      "types": "./dist/index.d.mts"
+    }
   },
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,7 +57,11 @@ const mainConfig = {
 /** @type {import('rollup').RollupOptions} */
 const typesConfig = {
   input: 'src/index.ts',
-  output: [{ file: 'dist/index.d.ts', format: 'es' }],
+  output: [
+    { file: 'dist/index.d.ts', format: 'es' },
+    { file: 'dist/index.d.cts', format: 'es' },
+    { file: 'dist/index.d.mts', format: 'es' },
+  ],
   external: [...external, 'polka', 'axe-core'],
   plugins: [dts({ respectExternal: true })],
 };


### PR DESCRIPTION
When a project that uses pleasantest uses TS with `moduleResolution: nodenext`, TS becomes unhappy with pleasantest because it interprets the .d.ts as a non-ESM file, even though it was imported as an ESM.

This is all a big headache. I'm going to do my best to explain it but I might be a little bit wrong:

If a `.ts` file is authored as a module (e.g. it has import statements), it may be either _compiled_ to commonjs or _compiled_ to a module.

If a file with import statements is compiled to commonjs, there is potentially a problem where that file may have had `import 'some-esm-file'` which would get transpiled to `require('some-esm-file')`. But, importing an ESM file from a commonjs file is not allowed. So even though the file was authored in ESM (with import statements), since it was transpiled to commonjs, it would no longer be valid.

To fix this real problem (ignoring typescript), pleasantest has an export map in `package.json`, so that a user can `require('pleasantest')` or `import 'pleasantest'`. This export map says "when you require me, load this CJS file, when you import me, load this ESM file".

This all works fine at runtime but TS doesn't know about it and thinks there is still a problem. When I create a project with these TS settings:

```
    "module": "Node16",
    "moduleResolution": "Node16",
```

then I get the following error:

```
The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("pleasantest")' call instead.
  To convert this file to an ECMAScript module, change its file extension to '.mts', or add the field `"type": "module"` to '/Users/calebeby/Projects/tmp-ts-pt-modules/package.json'.ts(1479)
```

This TS error is not helpful because at runtime everything is fine (the export map handles all the CJS/ESM interop as necessary).

To work around this, I added separate `types` fields for each of the parts of the export map, pointing to `.d.cts` and `.d.mts` files. `types.d.cts`, `types.d.mts`, and `types.d.ts` all have exactly the same contents.

I wish we'd gotten ES modules sooner so that we wouldn't have ever had to deal with pretending that import and export were syntax sugar for require and module.exports. It causes so many headaches now.