### PR TITLE
Bugfix: fix URL path for childProcess.fork when using Pleasantest from ESM

### DIFF
--- a/.changeset/calm-windows-retire.md
+++ b/.changeset/calm-windows-retire.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': minor
+---
+
+Fix fork URL for ESM use

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -91,14 +91,6 @@ function bundlePlugin() {
 
       return resolved;
     },
-    resolveImportMeta(property, { format }) {
-      if (property === 'url' && format === 'cjs') {
-        // eslint-disable-next-line no-template-curly-in-string
-        return '`file://${__filename}`';
-      }
-
-      return null;
-    },
     async load(id) {
       if (!id.startsWith('\0bundle:')) return;
       id = id.slice(8);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -91,11 +91,6 @@ function bundlePlugin() {
 
       return resolved;
     },
-    resolveFileUrl({ relativePath, format }) {
-      return format === 'es'
-        ? `new URL('${relativePath}', import.meta.url).href`
-        : `require('path').join(__dirname,'${relativePath}')`;
-    },
     resolveImportMeta(property, { format }) {
       if (property === 'url' && format === 'cjs') {
         // eslint-disable-next-line no-template-curly-in-string

--- a/src/connect-to-browser.ts
+++ b/src/connect-to-browser.ts
@@ -111,10 +111,13 @@ export const connectToBrowser = async (
     return connectedBrowser;
   }
 
-  const subprocess = childProcess.fork(startDisownedBrowserPath, {
-    detached: true,
-    stdio: 'ignore',
-  });
+  const subprocess = childProcess.fork(
+    fileURLToPath(startDisownedBrowserPath),
+    {
+      detached: true,
+      stdio: 'ignore',
+    },
+  );
   const wsEndpoint = await new Promise<string>((resolve, reject) => {
     subprocess.send({ browser, headless });
     subprocess.on('message', (msg: any) => {


### PR DESCRIPTION
`childProcess.fork` does not accept a `file://` path. It requires a regular path. The `resolveFileUrl` function I put in the rollup config returned a `file://` path for ESM bundles and a regular path for CJS bundles. This meant that CJS bundles worked but ESM bundles didn't. This PR removes the `resolveFileUrl` in favor of rollup's built-in version, which always returns a `file://` path. Then when we pass it to `childProcess.fork` we use `fileURLToPath` to switch it back.

Unfortunately we don't have any test cases for using Jest's experimental ESM with pleasantest. I manually created a repo to test this. I hope to add a monorepo setup to pleasantest so that we can create test cases with Jest's experimental ESM without forcing us to switch all our tests over.