### PR TITLE
Re-export devices from `puppeteer.KnownDevices` instead of deprecated `puppeteer.devices`

### DIFF
--- a/.changeset/silver-countries-fail.md
+++ b/.changeset/silver-countries-fail.md
@@ -1,0 +1,5 @@
+---
+'pleasantest': minor
+---
+
+Re-export devices from `puppeteer.KnownDevices` instead of deprecated `puppeteer.devices`

--- a/src/index.ts
+++ b/src/index.ts
@@ -536,7 +536,7 @@ export const configureDefaults = (options: WithBrowserOpts) => {
   defaultOptions = options;
 };
 
-export const devices = puppeteer.devices;
+export const devices = puppeteer.KnownDevices;
 
 afterAll(async () => {
   await cleanupClientRuntimeServer();


### PR DESCRIPTION
See https://pptr.dev/api/puppeteer.devices/